### PR TITLE
Add approximate dB SPL display

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,13 +11,13 @@ function formatDuration(ms: number): string {
   return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
-function normalizeDb(db: number): number {
-  // dB range: -160 ~ 0, normalize to 0 ~ 1
-  return Math.max(0, Math.min(1, (db + 160) / 160));
+function normalizeDbSpl(dbSpl: number): number {
+  // dB SPL range: 0 ~ 130, normalize to 0 ~ 1
+  return Math.max(0, Math.min(1, dbSpl / 130));
 }
 
 export default function App() {
-  const { status, metering, isRecording, durationMillis, uri, start, stop } =
+  const { status, dbSpl, isRecording, durationMillis, uri, start, stop } =
     useRecorder();
 
   const appState = useRef(AppState.currentState);
@@ -47,7 +47,7 @@ export default function App() {
     }
   }, [uri, isRecording]);
 
-  const barWidth = normalizeDb(metering) * 100;
+  const barWidth = normalizeDbSpl(dbSpl) * 100;
 
   return (
     <View style={styles.container}>
@@ -62,7 +62,8 @@ export default function App() {
       )}
 
       <View style={styles.meterContainer}>
-        <Text style={styles.dbValue}>{metering.toFixed(1)} dB</Text>
+        <Text style={styles.dbValue}>{dbSpl.toFixed(1)} dB</Text>
+        <Text style={styles.dbLabel}>approx. SPL</Text>
         <View style={styles.barBackground}>
           <View style={[styles.barFill, { width: `${barWidth}%` }]} />
         </View>
@@ -119,6 +120,11 @@ const styles = StyleSheet.create({
     fontSize: 48,
     fontWeight: "bold",
     fontVariant: ["tabular-nums"],
+    marginBottom: 4,
+  },
+  dbLabel: {
+    fontSize: 12,
+    color: "#999",
     marginBottom: 12,
   },
   barBackground: {

--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -15,6 +15,10 @@ const RECORDING_OPTIONS = {
 
 const POLLING_INTERVAL_MS = 100;
 
+// Approximate offset to convert dBFS to dB SPL.
+// This is a rough estimate; accurate conversion requires per-device calibration.
+const DBFS_TO_SPL_OFFSET = 100;
+
 export type RecorderStatus = "idle" | "recording" | "permission_denied";
 
 async function requestNotificationPermission(): Promise<void> {
@@ -59,9 +63,13 @@ export function useRecorder() {
     setStatus("idle");
   }, [recorder]);
 
+  const meteringDbfs = state.metering ?? -160;
+  const dbSpl = Math.max(0, meteringDbfs + DBFS_TO_SPL_OFFSET);
+
   return {
     status,
-    metering: state.metering ?? -160,
+    metering: meteringDbfs,
+    dbSpl,
     isRecording: state.isRecording,
     durationMillis: state.durationMillis,
     uri: recorder.uri,


### PR DESCRIPTION
## Summary
- dBFS を固定オフセット（+100）で近似 dB SPL に変換して表示
- バーの表示範囲を 0〜130 dB SPL に変更
- 「approx. SPL」ラベルを追加（近似値であることを明示）
- 正確なキャリブレーションは #13 で対応予定

## 変更ファイル
- `src/hooks/useRecorder.ts` — `dbSpl` フィールド追加（dBFS + 100, 下限0）
- `App.tsx` — dB SPL 表示に切り替え、バー正規化を SPL 基準に変更

## Test plan
- [ ] 録音開始し、静かな環境で 30〜40 dB 程度の値が表示されるか確認
- [ ] 声を出して 60〜80 dB 程度に上がるか確認
- [ ] 「approx. SPL」ラベルが表示されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)