### PR TITLE
Add automatic file splitting for long recordings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useRef, useState } from "react";
 import { AppState, StyleSheet, Text, TouchableOpacity, View } from "react-native";
-import { File } from "expo-file-system/next";
 import { StatusBar } from "expo-status-bar";
 import { useRecorder } from "@/hooks/useRecorder";
 
 function formatDuration(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
+  if (hours > 0) {
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  }
   return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
@@ -17,13 +20,18 @@ function normalizeDbSpl(dbSpl: number): number {
 }
 
 export default function App() {
-  const { status, dbSpl, isRecording, durationMillis, uri, start, stop } =
-    useRecorder();
+  const {
+    status,
+    dbSpl,
+    isRecording,
+    totalDurationMillis,
+    savedFiles,
+    start,
+    stop,
+  } = useRecorder();
 
   const appState = useRef(AppState.currentState);
   const [appStateLabel, setAppStateLabel] = useState(AppState.currentState);
-
-  const [fileSize, setFileSize] = useState<string | null>(null);
 
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (nextAppState) => {
@@ -32,20 +40,6 @@ export default function App() {
     });
     return () => subscription.remove();
   }, []);
-
-  useEffect(() => {
-    if (uri && !isRecording) {
-      const file = new File(uri);
-      if (file.exists) {
-        const size = file.size ?? 0;
-        const kb = (size / 1024).toFixed(1);
-        const mb = (size / 1024 / 1024).toFixed(2);
-        setFileSize(size > 1024 * 1024 ? `${mb} MB` : `${kb} KB`);
-      }
-    } else {
-      setFileSize(null);
-    }
-  }, [uri, isRecording]);
 
   const barWidth = normalizeDbSpl(dbSpl) * 100;
 
@@ -69,7 +63,7 @@ export default function App() {
         </View>
       </View>
 
-      <Text style={styles.duration}>{formatDuration(durationMillis)}</Text>
+      <Text style={styles.duration}>{formatDuration(totalDurationMillis)}</Text>
 
       <TouchableOpacity
         style={[styles.button, isRecording && styles.buttonStop]}
@@ -80,11 +74,10 @@ export default function App() {
         </Text>
       </TouchableOpacity>
 
-      {uri && !isRecording && (
-        <>
-          <Text style={styles.uri}>保存先: {uri}</Text>
-          {fileSize && <Text style={styles.uri}>ファイルサイズ: {fileSize}</Text>}
-        </>
+      {savedFiles.length > 0 && (
+        <Text style={styles.uri}>
+          {savedFiles.length} file{savedFiles.length !== 1 ? "s" : ""} saved
+        </Text>
       )}
 
       <StatusBar style="auto" />

--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -1,12 +1,15 @@
-import { useCallback, useEffect, useState } from "react";
-import { Platform, PermissionsAndroid } from "react-native";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AppState, Platform, PermissionsAndroid } from "react-native";
 import {
-  useAudioRecorder,
-  useAudioRecorderState,
   RecordingPresets,
   requestRecordingPermissionsAsync,
   setAudioModeAsync,
 } from "expo-audio";
+import type { RecorderState } from "expo-audio";
+import { requireNativeModule } from "expo-modules-core";
+import { moveRecording } from "@/utils/fileManager";
+
+const AudioModule = requireNativeModule("ExpoAudio");
 
 const RECORDING_OPTIONS = {
   ...RecordingPresets.HIGH_QUALITY,
@@ -14,6 +17,7 @@ const RECORDING_OPTIONS = {
 };
 
 const POLLING_INTERVAL_MS = 100;
+const SPLIT_INTERVAL_MS = 3_600_000; // 1 hour
 
 // Approximate offset to convert dBFS to dB SPL.
 // This is a rough estimate; accurate conversion requires per-device calibration.
@@ -29,8 +33,25 @@ async function requestNotificationPermission(): Promise<void> {
   }
 }
 
+function createRecorder() {
+  return new AudioModule.AudioRecorder(RECORDING_OPTIONS);
+}
+
 export function useRecorder() {
   const [status, setStatus] = useState<RecorderStatus>("idle");
+  const [metering, setMetering] = useState<number | undefined>(undefined);
+  const [isRecording, setIsRecording] = useState(false);
+  const [savedFiles, setSavedFiles] = useState<string[]>([]);
+  const [completedDurationMillis, setCompletedDurationMillis] = useState(0);
+  // Wall-clock elapsed time for the current segment, updated by polling / resume
+  const [segmentElapsedMillis, setSegmentElapsedMillis] = useState(0);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recorderRef = useRef<any>(null);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isSplittingRef = useRef(false);
+  // Wall-clock timestamp when the current segment started recording
+  const segmentStartRef = useRef<number>(0);
 
   // Set audio mode early so the native recorder inherits allowsBackgroundRecording
   useEffect(() => {
@@ -41,8 +62,105 @@ export function useRecorder() {
     });
   }, []);
 
-  const recorder = useAudioRecorder(RECORDING_OPTIONS);
-  const state = useAudioRecorderState(recorder, POLLING_INTERVAL_MS);
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current != null) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (recorder: any) => {
+      stopPolling();
+      pollingRef.current = setInterval(() => {
+        try {
+          const newState: RecorderState = recorder.getStatus();
+          setMetering(newState.metering);
+          setIsRecording(newState.isRecording);
+          setSegmentElapsedMillis(Date.now() - segmentStartRef.current);
+        } catch {
+          // Recorder may have been released during split
+        }
+      }, POLLING_INTERVAL_MS);
+    },
+    [stopPolling]
+  );
+
+  const splitRecording = useCallback(async () => {
+    if (isSplittingRef.current) return;
+    isSplittingRef.current = true;
+
+    const oldRecorder = recorderRef.current;
+    if (!oldRecorder) {
+      isSplittingRef.current = false;
+      return;
+    }
+
+    stopPolling();
+
+    const segmentDuration = Date.now() - segmentStartRef.current;
+
+    await oldRecorder.stop();
+    const oldUri = oldRecorder.uri;
+
+    // Start new recorder immediately
+    const newRecorder = createRecorder();
+    recorderRef.current = newRecorder;
+    await newRecorder.prepareToRecordAsync(RECORDING_OPTIONS);
+    newRecorder.record();
+    segmentStartRef.current = Date.now();
+    startPolling(newRecorder);
+
+    // Move the old file to permanent storage
+    if (oldUri) {
+      const savedPath = moveRecording(oldUri);
+      setSavedFiles((prev) => [...prev, savedPath]);
+    }
+
+    setCompletedDurationMillis((prev) => prev + segmentDuration);
+    setSegmentElapsedMillis(0);
+    isSplittingRef.current = false;
+  }, [stopPolling, startPolling]);
+
+  // Check if split is needed (wall-clock based)
+  useEffect(() => {
+    if (
+      isRecording &&
+      !isSplittingRef.current &&
+      segmentElapsedMillis >= SPLIT_INTERVAL_MS
+    ) {
+      splitRecording();
+    }
+  }, [segmentElapsedMillis, isRecording, splitRecording]);
+
+  // Restart polling and refresh state when returning to foreground.
+  // setInterval stops firing while the app is in the background;
+  // we recreate it on resume so the UI keeps updating.
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextAppState) => {
+      const recorder = recorderRef.current;
+      if (nextAppState === "active" && recorder) {
+        setSegmentElapsedMillis(Date.now() - segmentStartRef.current);
+        try {
+          const s: RecorderState = recorder.getStatus();
+          setMetering(s.metering);
+          setIsRecording(s.isRecording);
+        } catch {
+          // Recorder may have been released
+        }
+        startPolling(recorder);
+      }
+    });
+    return () => subscription.remove();
+  }, [startPolling]);
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      stopPolling();
+    };
+  }, [stopPolling]);
 
   const start = useCallback(async () => {
     const { granted } = await requestRecordingPermissionsAsync();
@@ -53,26 +171,50 @@ export function useRecorder() {
 
     await requestNotificationPermission();
 
-    await recorder.prepareToRecordAsync();
+    const recorder = createRecorder();
+    recorderRef.current = recorder;
+    await recorder.prepareToRecordAsync(RECORDING_OPTIONS);
     recorder.record();
+
+    segmentStartRef.current = Date.now();
+    setSavedFiles([]);
+    setCompletedDurationMillis(0);
+    setSegmentElapsedMillis(0);
+    startPolling(recorder);
     setStatus("recording");
-  }, [recorder]);
+  }, [startPolling]);
 
   const stop = useCallback(async () => {
-    await recorder.stop();
+    stopPolling();
+    const recorder = recorderRef.current;
+    if (recorder) {
+      const segmentDuration = Date.now() - segmentStartRef.current;
+      await recorder.stop();
+      const uri = recorder.uri;
+      if (uri) {
+        const savedPath = moveRecording(uri);
+        setSavedFiles((prev) => [...prev, savedPath]);
+      }
+      setCompletedDurationMillis((prev) => prev + segmentDuration);
+      recorderRef.current = null;
+    }
+    setMetering(undefined);
+    setIsRecording(false);
+    setSegmentElapsedMillis(0);
     setStatus("idle");
-  }, [recorder]);
+  }, [stopPolling]);
 
-  const meteringDbfs = state.metering ?? -160;
+  const meteringDbfs = metering ?? -160;
   const dbSpl = Math.max(0, meteringDbfs + DBFS_TO_SPL_OFFSET);
+  const totalDurationMillis = completedDurationMillis + segmentElapsedMillis;
 
   return {
     status,
     metering: meteringDbfs,
     dbSpl,
-    isRecording: state.isRecording,
-    durationMillis: state.durationMillis,
-    uri: recorder.uri,
+    isRecording,
+    totalDurationMillis,
+    savedFiles,
     start,
     stop,
   };

--- a/src/utils/fileManager.ts
+++ b/src/utils/fileManager.ts
@@ -1,0 +1,34 @@
+import { File, Directory, Paths } from "expo-file-system/next";
+
+const RECORDINGS_DIR = "recordings";
+
+function getRecordingDir(): Directory {
+  return new Directory(Paths.document, RECORDINGS_DIR);
+}
+
+export function ensureRecordingDir(): void {
+  const dir = getRecordingDir();
+  if (!dir.exists) {
+    dir.create();
+  }
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const y = date.getFullYear();
+  const mo = pad(date.getMonth() + 1);
+  const d = pad(date.getDate());
+  const h = pad(date.getHours());
+  const mi = pad(date.getMinutes());
+  const s = pad(date.getSeconds());
+  return `${y}-${mo}-${d}_${h}-${mi}-${s}`;
+}
+
+export function moveRecording(sourceUri: string): string {
+  ensureRecordingDir();
+  const filename = `recording_${formatTimestamp(new Date())}.m4a`;
+  const dest = new File(getRecordingDir(), filename);
+  const src = new File(sourceUri);
+  src.move(dest);
+  return dest.uri;
+}


### PR DESCRIPTION
## Summary
- 長時間録音を1時間ごとに自動分割して保存する機能を追加（stop → ファイル移動 → 新規録音開始方式）
- `useAudioRecorder` フックから `AudioRecorder` クラスの直接利用に変更し、分割ごとに新インスタンスを作成可能に
- ネイティブの `durationMillis` がバックグラウンドで進まない問題に対応し、壁時計（`Date.now()`）ベースで経過時間を計測

## Test plan
- [x] 分割間隔を10秒に変更してテスト、自動分割を確認済み
- [x] 分割時に録音が途切れず再開されることを確認済み
- [x] バックグラウンドでもタイマーが正しく進むことを確認済み
- [ ] `Paths.document/recordings/` にファイルが正しい名前で保存されるか確認（→ ファイル一覧画面で対応予定）

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)