### PR TITLE
Apply dark mode UI and show real-world time on dB graph

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import HomeScreen from "@/screens/HomeScreen";
 import RecordingsScreen from "@/screens/RecordingsScreen";
 import PlaybackScreen from "@/screens/PlaybackScreen";
+import colors from "@/theme/colors";
 
 export type RootStackParamList = {
   Home: undefined;
@@ -15,7 +16,14 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 export default function App() {
   return (
     <NavigationContainer>
-      <Stack.Navigator initialRouteName="Home">
+      <Stack.Navigator
+        initialRouteName="Home"
+        screenOptions={{
+          headerStyle: { backgroundColor: colors.bgSecondary },
+          headerTintColor: colors.textPrimary,
+          headerTitleStyle: { color: colors.textPrimary },
+        }}
+      >
         <Stack.Screen
           name="Home"
           component={HomeScreen}

--- a/src/components/DbGraph.tsx
+++ b/src/components/DbGraph.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Pressable, ScrollView } from "react-native";
 import Svg, { Line, Path, Rect, Text as SvgText } from "react-native-svg";
+import colors from "@/theme/colors";
 import type { DecibelPoint } from "@/utils/csvParser";
 
 type Props = {
@@ -9,6 +10,7 @@ type Props = {
   currentTimeMs: number;
   viewportWidth: number;
   height: number;
+  startTimestamp: string;
   onSeek: (ms: number) => void;
 };
 
@@ -23,14 +25,14 @@ const MARGIN_TOP = 24;
 
 const LABEL_FONT_SIZE = 10;
 const CURSOR_FONT_SIZE = 11;
-const GRID_COLOR = "#e2e8f0";
-const GRID_LABEL_COLOR = "#a0aec0";
+const GRID_COLOR = colors.borderStrong;
+const GRID_LABEL_COLOR = colors.textTertiary;
 
-function formatTimeLabel(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const h = Math.floor(totalSeconds / 3600);
-  const m = Math.floor((totalSeconds % 3600) / 60);
-  const s = totalSeconds % 60;
+function formatTimeLabel(ms: number, startEpochMs: number): string {
+  const date = new Date(startEpochMs + ms);
+  const h = date.getHours();
+  const m = date.getMinutes();
+  const s = date.getSeconds();
   return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 }
 
@@ -54,8 +56,10 @@ export default function DbGraph({
   currentTimeMs,
   viewportWidth,
   height,
+  startTimestamp,
   onSeek,
 }: Props) {
+  const startEpochMs = useMemo(() => new Date(startTimestamp).getTime(), [startTimestamp]);
   const scrollRef = useRef<ScrollView>(null);
   const isUserScrolling = useRef(false);
   const scrollTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -140,7 +144,7 @@ export default function DbGraph({
 
   // --- Cursor label positioning (avoid clipping at edges) ---
   const cursorDbLabel = `${currentDb.toFixed(0)} dB`;
-  const cursorTimeLabel = formatTimeLabel(currentTimeMs);
+  const cursorTimeLabel = formatTimeLabel(currentTimeMs, startEpochMs);
   const labelWidth = 56;
   const labelHalf = labelWidth / 2;
 
@@ -195,7 +199,7 @@ export default function DbGraph({
             y={MARGIN_TOP}
             width={totalPlotWidth}
             height={plotHeight}
-            fill="#f7fafc"
+            fill={colors.bgSecondary}
           />
 
           {/* --- Horizontal grid lines (dB) + Y-axis labels --- */}
@@ -244,13 +248,13 @@ export default function DbGraph({
               fontSize={LABEL_FONT_SIZE}
               fill={GRID_LABEL_COLOR}
             >
-              {formatTimeLabel(ms)}
+              {formatTimeLabel(ms, startEpochMs)}
             </SvgText>
           ))}
 
           {/* --- Data line --- */}
           {pathD !== "" && (
-            <Path d={pathD} fill="none" stroke="#3182ce" strokeWidth={1.5} />
+            <Path d={pathD} fill="none" stroke={colors.accentBlue} strokeWidth={1.5} />
           )}
 
           {/* --- Cursor line --- */}
@@ -259,7 +263,7 @@ export default function DbGraph({
             y1={MARGIN_TOP}
             x2={cursorX}
             y2={MARGIN_TOP + plotHeight}
-            stroke="#e53e3e"
+            stroke={colors.accentRed}
             strokeWidth={2}
           />
 
@@ -270,7 +274,7 @@ export default function DbGraph({
             width={labelWidth}
             height={16}
             rx={3}
-            fill="#e53e3e"
+            fill={colors.accentRed}
           />
           <SvgText
             x={labelCenterX}
@@ -278,7 +282,7 @@ export default function DbGraph({
             textAnchor="middle"
             fontSize={CURSOR_FONT_SIZE}
             fontWeight="bold"
-            fill="#fff"
+            fill={colors.onAccent}
           >
             {cursorDbLabel}
           </SvgText>
@@ -290,7 +294,7 @@ export default function DbGraph({
             width={labelWidth}
             height={16}
             rx={3}
-            fill="#e53e3e"
+            fill={colors.accentRed}
           />
           <SvgText
             x={labelCenterX}
@@ -298,7 +302,7 @@ export default function DbGraph({
             textAnchor="middle"
             fontSize={CURSOR_FONT_SIZE}
             fontWeight="bold"
-            fill="#fff"
+            fill={colors.onAccent}
           >
             {cursorTimeLabel}
           </SvgText>

--- a/src/hooks/usePlaybackData.ts
+++ b/src/hooks/usePlaybackData.ts
@@ -3,9 +3,9 @@ import { File } from "expo-file-system/next";
 import { parseCsv, downsample, type DecibelPoint } from "@/utils/csvParser";
 
 type PlaybackDataResult =
-  | { status: "loading"; points: null; durationMs: 0 }
-  | { status: "error"; points: null; durationMs: 0 }
-  | { status: "ready"; points: DecibelPoint[]; durationMs: number };
+  | { status: "loading"; points: null; durationMs: 0; startTimestamp: "" }
+  | { status: "error"; points: null; durationMs: 0; startTimestamp: "" }
+  | { status: "ready"; points: DecibelPoint[]; durationMs: number; startTimestamp: string };
 
 export function usePlaybackData(
   audioUri: string,
@@ -15,11 +15,12 @@ export function usePlaybackData(
     status: "loading",
     points: null,
     durationMs: 0,
+    startTimestamp: "",
   });
 
   useEffect(() => {
     let cancelled = false;
-    setResult({ status: "loading", points: null, durationMs: 0 });
+    setResult({ status: "loading", points: null, durationMs: 0, startTimestamp: "" });
 
     async function load() {
       try {
@@ -27,22 +28,23 @@ export function usePlaybackData(
         const csvFile = new File(csvUri);
         if (!csvFile.exists) {
           if (!cancelled)
-            setResult({ status: "error", points: null, durationMs: 0 });
+            setResult({ status: "error", points: null, durationMs: 0, startTimestamp: "" });
           return;
         }
         const content = await csvFile.text();
         if (cancelled) return;
         const points = parseCsv(content);
         if (points.length === 0) {
-          setResult({ status: "error", points: null, durationMs: 0 });
+          setResult({ status: "error", points: null, durationMs: 0, startTimestamp: "" });
           return;
         }
         const dur = points[points.length - 1].offsetMs;
+        const startTimestamp = points[0].timestamp;
         const sampled = downsample(points, maxPoints);
-        setResult({ status: "ready", points: sampled, durationMs: dur });
+        setResult({ status: "ready", points: sampled, durationMs: dur, startTimestamp });
       } catch {
         if (!cancelled)
-          setResult({ status: "error", points: null, durationMs: 0 });
+          setResult({ status: "error", points: null, durationMs: 0, startTimestamp: "" });
       }
     }
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -3,6 +3,7 @@ import { AppState, StyleSheet, Text, TouchableOpacity, View } from "react-native
 import { StatusBar } from "expo-status-bar";
 import { useRecorder } from "@/hooks/useRecorder";
 import { formatDuration } from "@/utils/formatDuration";
+import colors from "@/theme/colors";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { RootStackParamList } from "../../App";
 
@@ -80,7 +81,7 @@ export default function HomeScreen({ navigation }: Props) {
         <Text style={styles.navButtonText}>ファイル一覧</Text>
       </TouchableOpacity>
 
-      <StatusBar style="auto" />
+      <StatusBar style="light" />
     </View>
   );
 }
@@ -88,7 +89,7 @@ export default function HomeScreen({ navigation }: Props) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff",
+    backgroundColor: colors.bgPrimary,
     alignItems: "center",
     justifyContent: "center",
     paddingHorizontal: 24,
@@ -97,9 +98,10 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: "bold",
     marginBottom: 32,
+    color: colors.textPrimary,
   },
   warning: {
-    color: "#e53e3e",
+    color: colors.accentRed,
     fontSize: 14,
     marginBottom: 16,
     textAlign: "center",
@@ -114,65 +116,66 @@ const styles = StyleSheet.create({
     fontWeight: "bold",
     fontVariant: ["tabular-nums"],
     marginBottom: 4,
+    color: colors.textPrimary,
   },
   dbLabel: {
     fontSize: 12,
-    color: "#999",
+    color: colors.textTertiary,
     marginBottom: 12,
   },
   barBackground: {
     width: "100%",
     height: 20,
-    backgroundColor: "#e2e8f0",
+    backgroundColor: colors.borderStrong,
     borderRadius: 10,
     overflow: "hidden",
   },
   barFill: {
     height: "100%",
-    backgroundColor: "#38a169",
+    backgroundColor: colors.accentGreen,
     borderRadius: 10,
   },
   duration: {
     fontSize: 20,
     fontVariant: ["tabular-nums"],
-    color: "#666",
+    color: colors.textSecondary,
     marginBottom: 24,
   },
   button: {
-    backgroundColor: "#3182ce",
+    backgroundColor: colors.accentBlue,
     paddingHorizontal: 32,
     paddingVertical: 14,
     borderRadius: 12,
     marginBottom: 16,
   },
   buttonStop: {
-    backgroundColor: "#e53e3e",
+    backgroundColor: colors.accentRed,
   },
   buttonText: {
-    color: "#fff",
+    color: colors.onAccent,
     fontSize: 18,
     fontWeight: "bold",
   },
   uri: {
     fontSize: 12,
-    color: "#999",
+    color: colors.textTertiary,
     textAlign: "center",
     marginBottom: 16,
   },
   appState: {
     fontSize: 14,
-    color: "#888",
+    color: colors.textTertiary,
     marginBottom: 16,
   },
   navButton: {
-    backgroundColor: "#805ad5",
+    backgroundColor: colors.accentPurple,
     paddingHorizontal: 24,
     paddingVertical: 12,
     borderRadius: 12,
     marginTop: 8,
   },
   navButtonText: {
-    color: "#fff",
+    color: colors.onAccent,
     fontSize: 16,
     fontWeight: "bold",
   },

--- a/src/screens/PlaybackScreen.tsx
+++ b/src/screens/PlaybackScreen.tsx
@@ -8,6 +8,7 @@ import {
 import { usePlaybackData } from "@/hooks/usePlaybackData";
 import { formatDuration } from "@/utils/formatDuration";
 import DbGraph from "@/components/DbGraph";
+import colors from "@/theme/colors";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { RootStackParamList } from "../../App";
 
@@ -103,6 +104,7 @@ export default function PlaybackScreen({ route }: Props) {
               currentTimeMs={currentTimeMs}
               viewportWidth={viewportWidth}
               height={250}
+              startTimestamp={playbackData.startTimestamp}
               onSeek={handleSeek}
             />
           )}
@@ -126,9 +128,9 @@ export default function PlaybackScreen({ route }: Props) {
           onSlidingStart={handleSlidingStart}
           onValueChange={handleSliderChange}
           onSlidingComplete={handleSlidingComplete}
-          minimumTrackTintColor="#3182ce"
-          maximumTrackTintColor="#e2e8f0"
-          thumbTintColor="#3182ce"
+          minimumTrackTintColor={colors.accentBlue}
+          maximumTrackTintColor={colors.borderStrong}
+          thumbTintColor={colors.accentBlue}
         />
 
         <TouchableOpacity
@@ -147,12 +149,12 @@ export default function PlaybackScreen({ route }: Props) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff",
+    backgroundColor: colors.bgPrimary,
   },
   fileName: {
     fontSize: 14,
     fontWeight: "500",
-    color: "#2d3748",
+    color: colors.textPrimary,
     paddingHorizontal: 16,
     paddingTop: 16,
     paddingBottom: 8,
@@ -160,7 +162,7 @@ const styles = StyleSheet.create({
   graphContainer: {
     flex: 1,
     marginHorizontal: 16,
-    backgroundColor: "#f7fafc",
+    backgroundColor: colors.bgSecondary,
     borderRadius: 8,
     overflow: "hidden",
     justifyContent: "center",
@@ -172,11 +174,11 @@ const styles = StyleSheet.create({
   },
   placeholderText: {
     fontSize: 14,
-    color: "#a0aec0",
+    color: colors.textMuted,
   },
   errorText: {
     fontSize: 14,
-    color: "#e53e3e",
+    color: colors.accentRed,
   },
   controls: {
     paddingHorizontal: 16,
@@ -191,7 +193,7 @@ const styles = StyleSheet.create({
   time: {
     fontSize: 14,
     fontVariant: ["tabular-nums"],
-    color: "#4a5568",
+    color: colors.textSecondary,
   },
   slider: {
     width: "100%",
@@ -199,14 +201,14 @@ const styles = StyleSheet.create({
   },
   playButton: {
     alignSelf: "center",
-    backgroundColor: "#3182ce",
+    backgroundColor: colors.accentBlue,
     paddingHorizontal: 32,
     paddingVertical: 14,
     borderRadius: 12,
     marginTop: 8,
   },
   playButtonText: {
-    color: "#fff",
+    color: colors.onAccent,
     fontSize: 18,
     fontWeight: "bold",
   },

--- a/src/screens/RecordingsScreen.tsx
+++ b/src/screens/RecordingsScreen.tsx
@@ -16,6 +16,7 @@ import {
   deleteAllRecordings,
   type RecordingFile,
 } from "@/utils/fileManager";
+import colors from "@/theme/colors";
 
 type Props = NativeStackScreenProps<RootStackParamList, "Recordings">;
 
@@ -169,7 +170,7 @@ export default function RecordingsScreen({ navigation }: Props) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff",
+    backgroundColor: colors.bgPrimary,
   },
   toolbar: {
     flexDirection: "row",
@@ -178,7 +179,7 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     gap: 8,
     borderBottomWidth: 1,
-    borderBottomColor: "#e2e8f0",
+    borderBottomColor: colors.borderStrong,
   },
   toolbarButton: {
     paddingHorizontal: 16,
@@ -186,16 +187,16 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   deleteButton: {
-    backgroundColor: "#e53e3e",
+    backgroundColor: colors.accentRed,
   },
   deleteAllButton: {
-    backgroundColor: "#dd6b20",
+    backgroundColor: colors.accentOrange,
   },
   buttonDisabled: {
     opacity: 0.4,
   },
   toolbarButtonText: {
-    color: "#fff",
+    color: colors.onAccent,
     fontSize: 14,
     fontWeight: "bold",
   },
@@ -208,17 +209,17 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 14,
     borderBottomWidth: 1,
-    borderBottomColor: "#f0f0f0",
+    borderBottomColor: colors.borderSubtle,
   },
   rowSelected: {
-    backgroundColor: "#ebf8ff",
+    backgroundColor: colors.highlight,
   },
   checkbox: {
     width: 24,
     height: 24,
     borderRadius: 4,
     borderWidth: 2,
-    borderColor: "#a0aec0",
+    borderColor: colors.textMuted,
     marginRight: 12,
     alignItems: "center",
     justifyContent: "center",
@@ -227,7 +228,7 @@ const styles = StyleSheet.create({
     width: 14,
     height: 14,
     borderRadius: 2,
-    backgroundColor: "#3182ce",
+    backgroundColor: colors.accentBlue,
   },
   fileInfo: {
     flex: 1,
@@ -235,12 +236,12 @@ const styles = StyleSheet.create({
   fileName: {
     fontSize: 14,
     fontWeight: "500",
-    color: "#2d3748",
+    color: colors.textPrimary,
     marginBottom: 2,
   },
   fileMeta: {
     fontSize: 12,
-    color: "#a0aec0",
+    color: colors.textMuted,
   },
   listFooter: {
     alignItems: "center",
@@ -250,7 +251,7 @@ const styles = StyleSheet.create({
     width: 6,
     height: 6,
     borderRadius: 3,
-    backgroundColor: "#cbd5e0",
+    backgroundColor: colors.textMuted,
   },
   emptyContainer: {
     flex: 1,
@@ -259,6 +260,6 @@ const styles = StyleSheet.create({
   },
   emptyText: {
     fontSize: 16,
-    color: "#a0aec0",
+    color: colors.textMuted,
   },
 });

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,31 @@
+/** Dark-mode colour palette – bluish-grey base */
+const colors = {
+  // Backgrounds
+  bgPrimary: "#0f1117",
+  bgSecondary: "#1a1d27",
+
+  // Borders
+  borderStrong: "#2d3148",
+  borderSubtle: "#252839",
+
+  // Text
+  textPrimary: "#e2e6ef",
+  textSecondary: "#9ba3b5",
+  textTertiary: "#6b7280",
+  textMuted: "#525b6b",
+
+  // Accents
+  accentBlue: "#5b9bd5",
+  accentPurple: "#9b7de8",
+  accentRed: "#e05555",
+  accentOrange: "#d4803a",
+  accentGreen: "#4eaa72",
+
+  // Selection
+  highlight: "#1a2a3a",
+
+  // On accent (text on coloured buttons)
+  onAccent: "#fff",
+} as const;
+
+export default colors;

--- a/src/utils/csvParser.ts
+++ b/src/utils/csvParser.ts
@@ -1,4 +1,8 @@
-export type DecibelPoint = { offsetMs: number; dbSpl: number };
+export type DecibelPoint = {
+  offsetMs: number;
+  dbSpl: number;
+  timestamp: string;
+};
 
 export function parseCsv(content: string): DecibelPoint[] {
   const lines = content.split("\n");
@@ -8,10 +12,11 @@ export function parseCsv(content: string): DecibelPoint[] {
     if (line === "") continue;
     const parts = line.split(",");
     // CSV format: timestamp, offset_ms, db (dBFS)
+    const timestamp = parts[0];
     const offsetMs = Number(parts[1]);
     const dbfs = Number(parts[2]);
-    if (Number.isNaN(offsetMs) || Number.isNaN(dbfs)) continue;
-    points.push({ offsetMs, dbSpl: Math.max(0, dbfs + 100) });
+    if (!timestamp || Number.isNaN(offsetMs) || Number.isNaN(dbfs)) continue;
+    points.push({ timestamp, offsetMs, dbSpl: Math.max(0, dbfs + 100) });
   }
   return points;
 }


### PR DESCRIPTION
## Summary
- **ダークモードUI**: 全画面を青みがかったグレー系ダークカラーに統一。共有カラー定数 `src/theme/colors.ts` を新設し、全画面・ナビヘッダー・グラフから参照
- **グラフX軸を実時刻表示**: CSVに記録済みのISOタイムスタンプを活用し、経過時間ではなく録音時の実世界の時刻(HH:MM:SS)をX軸ラベル・カーソルラベルに表示

Closes #21

## 変更ファイル
| ファイル | 概要 |
|---|---|
| `src/theme/colors.ts` | **新規** 共有ダークモードカラー定数 |
| `App.tsx` | ナビヘッダーダーク化 |
| `src/screens/HomeScreen.tsx` | 全色をcolors参照 + StatusBar light |
| `src/screens/RecordingsScreen.tsx` | 全色をcolors参照 |
| `src/screens/PlaybackScreen.tsx` | 全色をcolors参照 + startTimestamp伝播 |
| `src/components/DbGraph.tsx` | SVG色をcolors参照 + 実時刻表示 |
| `src/utils/csvParser.ts` | DecibelPointにtimestampフィールド追加 |
| `src/hooks/usePlaybackData.ts` | startTimestampを返却 |

## Test plan
- [ ] `tsc --noEmit` パス確認済み
- [ ] 全画面（Home / Recordings / Playback）が暗い背景で統一される
- [ ] ナビゲーションヘッダーも暗い
- [ ] テキストが全て読みやすい（暗黙の黒テキストがない）
- [ ] グラフのX軸ラベル・カーソルラベルが実世界の時刻を表示する
- [ ] グラフのグリッド線・ラベルが暗い背景上で視認できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)