### PR TITLE
録音画面にリアルタイムdBグラフと設定画面を追加

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,14 +1,17 @@
+import { TouchableOpacity, Text } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import HomeScreen from "@/screens/HomeScreen";
 import RecordingsScreen from "@/screens/RecordingsScreen";
 import PlaybackScreen from "@/screens/PlaybackScreen";
+import SettingsScreen from "@/screens/SettingsScreen";
 import colors from "@/theme/colors";
 
 export type RootStackParamList = {
   Home: undefined;
   Recordings: undefined;
   Playback: { uri: string; name: string };
+  Settings: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -27,7 +30,16 @@ export default function App() {
         <Stack.Screen
           name="Home"
           component={HomeScreen}
-          options={{ title: "Recording PoC" }}
+          options={({ navigation }) => ({
+            title: "Sound Level Recorder",
+            headerRight: () => (
+              <TouchableOpacity onPress={() => navigation.navigate("Settings")}>
+                <Text style={{ color: colors.textPrimary, fontSize: 22 }}>
+                  ⚙
+                </Text>
+              </TouchableOpacity>
+            ),
+          })}
         />
         <Stack.Screen
           name="Recordings"
@@ -38,6 +50,11 @@ export default function App() {
           name="Playback"
           component={PlaybackScreen}
           options={{ title: "再生" }}
+        />
+        <Stack.Screen
+          name="Settings"
+          component={SettingsScreen}
+          options={{ title: "設定" }}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/src/components/LiveDbGraph.tsx
+++ b/src/components/LiveDbGraph.tsx
@@ -1,0 +1,162 @@
+import { useMemo } from "react";
+import Svg, { Line, Path, Rect, Text as SvgText } from "react-native-svg";
+import colors from "@/theme/colors";
+import type { DecibelPoint } from "@/utils/csvParser";
+
+type Props = {
+  points: DecibelPoint[];
+  windowMs: number;
+  viewportWidth: number;
+  height: number;
+};
+
+const Y_MIN = 0;
+const Y_MAX = 130;
+const DB_STEP = 20;
+
+const MARGIN_LEFT = 36;
+const MARGIN_BOTTOM = 20;
+const MARGIN_TOP = 8;
+
+const LABEL_FONT_SIZE = 10;
+const GRID_COLOR = colors.borderStrong;
+const GRID_LABEL_COLOR = colors.textTertiary;
+
+function formatTimeLabel(epochMs: number): string {
+  const date = new Date(epochMs);
+  const h = date.getHours();
+  const m = date.getMinutes();
+  const s = date.getSeconds();
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+export default function LiveDbGraph({
+  points,
+  windowMs,
+  viewportWidth,
+  height,
+}: Props) {
+  const plotWidth = viewportWidth - MARGIN_LEFT;
+  const plotHeight = height - MARGIN_TOP - MARGIN_BOTTOM;
+
+  const nowMs = useMemo(() => {
+    if (points.length === 0) return Date.now();
+    // Use the latest point's timestamp as "now" for consistency
+    return new Date(points[points.length - 1].timestamp).getTime();
+  }, [points]);
+
+  const windowStartMs = nowMs - windowMs;
+
+  const dbToY = (db: number) => {
+    const clamped = Math.min(Math.max(db, Y_MIN), Y_MAX);
+    return MARGIN_TOP + plotHeight - ((clamped - Y_MIN) / (Y_MAX - Y_MIN)) * plotHeight;
+  };
+
+  const epochToX = (epochMs: number) => {
+    return MARGIN_LEFT + ((epochMs - windowStartMs) / windowMs) * plotWidth;
+  };
+
+  // Data path
+  const pathD = useMemo(() => {
+    if (points.length === 0) return "";
+    const parts: string[] = [];
+    for (let i = 0; i < points.length; i++) {
+      const epoch = new Date(points[i].timestamp).getTime();
+      const x = epochToX(epoch);
+      const y = dbToY(points[i].dbSpl);
+      parts.push(`${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`);
+    }
+    return parts.join(" ");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [points, windowStartMs, windowMs, plotWidth, plotHeight]);
+
+  // Horizontal grid lines (dB)
+  const dbGridLines = useMemo(() => {
+    const lines: { db: number; y: number }[] = [];
+    for (let db = Y_MIN; db <= Y_MAX; db += DB_STEP) {
+      lines.push({ db, y: dbToY(db) });
+    }
+    return lines;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [plotHeight]);
+
+  // Vertical grid lines (time) - 15 second interval
+  const timeGridLines = useMemo(() => {
+    const interval = 15_000;
+    const lines: { epochMs: number; x: number }[] = [];
+    const firstTick = Math.ceil(windowStartMs / interval) * interval;
+    for (let t = firstTick; t <= nowMs; t += interval) {
+      lines.push({ epochMs: t, x: epochToX(t) });
+    }
+    return lines;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [windowStartMs, nowMs, windowMs, plotWidth]);
+
+  return (
+    <Svg width={viewportWidth} height={height}>
+      {/* Plot background */}
+      <Rect
+        x={MARGIN_LEFT}
+        y={MARGIN_TOP}
+        width={plotWidth}
+        height={plotHeight}
+        fill={colors.bgSecondary}
+      />
+
+      {/* Horizontal grid lines (dB) + Y-axis labels */}
+      {dbGridLines.map(({ db, y }) => (
+        <Line
+          key={`hg-${db}`}
+          x1={MARGIN_LEFT}
+          y1={y}
+          x2={viewportWidth}
+          y2={y}
+          stroke={GRID_COLOR}
+          strokeWidth={1}
+        />
+      ))}
+      {dbGridLines.map(({ db, y }) => (
+        <SvgText
+          key={`hl-${db}`}
+          x={MARGIN_LEFT - 4}
+          y={y + 3}
+          textAnchor="end"
+          fontSize={LABEL_FONT_SIZE}
+          fill={GRID_LABEL_COLOR}
+        >
+          {db}
+        </SvgText>
+      ))}
+
+      {/* Vertical grid lines (time) + X-axis labels */}
+      {timeGridLines.map(({ epochMs, x }) => (
+        <Line
+          key={`vg-${epochMs}`}
+          x1={x}
+          y1={MARGIN_TOP}
+          x2={x}
+          y2={MARGIN_TOP + plotHeight}
+          stroke={GRID_COLOR}
+          strokeWidth={1}
+        />
+      ))}
+      {timeGridLines.map(({ epochMs, x }) => (
+        <SvgText
+          key={`vl-${epochMs}`}
+          x={x}
+          y={height - 4}
+          textAnchor="middle"
+          fontSize={LABEL_FONT_SIZE}
+          fill={GRID_LABEL_COLOR}
+        >
+          {formatTimeLabel(epochMs)}
+        </SvgText>
+      ))}
+
+      {/* Data line */}
+      {pathD !== "" && (
+        <Path d={pathD} fill="none" stroke={colors.accentBlue} strokeWidth={1.5} />
+      )}
+    </Svg>
+  );
+}

--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -46,7 +46,6 @@ const RECORDING_OPTIONS = {
 };
 
 const POLLING_INTERVAL_MS = 100;
-const SPLIT_INTERVAL_MS = 21_600_000; // 6 hours
 
 // Approximate offset to convert dBFS to dB SPL.
 // This is a rough estimate; accurate conversion requires per-device calibration.
@@ -66,7 +65,7 @@ function createRecorder() {
   return new AudioModule.AudioRecorder(RECORDING_OPTIONS);
 }
 
-export function useRecorder() {
+export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
   const [status, setStatus] = useState<RecorderStatus>("idle");
   const [metering, setMetering] = useState<number | undefined>(undefined);
   const [isRecording, setIsRecording] = useState(false);
@@ -117,18 +116,8 @@ export function useRecorder() {
             const offsetMs = now - segmentStartRef.current;
             insertDecibel(isoString, offsetMs, newState.metering);
           }
-
-          // Log every second in background for debugging
-          if (AppState.currentState === "background") {
-            const elapsed = now - segmentStartRef.current;
-            if (Math.floor(elapsed / 1000) !== Math.floor((elapsed - POLLING_INTERVAL_MS) / 1000)) {
-              console.log(
-                `[BG_METER] elapsed=${Math.floor(elapsed / 1000)}s isRecording=${newState.isRecording} metering=${newState.metering?.toFixed(1) ?? "null"}`
-              );
-            }
-          }
-        } catch (e) {
-          console.log(`[BG_METER] polling error: ${e}`);
+        } catch {
+          // Polling may fail if recorder was released
         }
       }, POLLING_INTERVAL_MS);
     },
@@ -172,7 +161,6 @@ export function useRecorder() {
       writeDecibelCsv(csvContent, audioFilename);
       deleteDecibelRows(fromIso, toIso);
 
-      console.log(`[BG_METER] split: ${audioFilename} duration=${segmentDuration}ms`);
     }
 
     setCompletedDurationMillis((prev) => prev + segmentDuration);
@@ -185,11 +173,12 @@ export function useRecorder() {
     if (
       isRecording &&
       !isSplittingRef.current &&
-      segmentElapsedMillis >= SPLIT_INTERVAL_MS
+      splitIntervalMs !== null &&
+      segmentElapsedMillis >= splitIntervalMs
     ) {
       splitRecording();
     }
-  }, [segmentElapsedMillis, isRecording, splitRecording]);
+  }, [segmentElapsedMillis, isRecording, splitIntervalMs, splitRecording]);
 
   // Restart polling and refresh state when returning to foreground.
   // setInterval may stop firing while the app is in the background on iOS;
@@ -198,7 +187,6 @@ export function useRecorder() {
     const subscription = AppState.addEventListener("change", (nextAppState) => {
       const recorder = recorderRef.current;
       if (nextAppState === "active" && recorder) {
-        console.log("[BG_METER] resumed foreground");
         setSegmentElapsedMillis(Date.now() - segmentStartRef.current);
         try {
           const s: RecorderState = recorder.getStatus();

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,19 +1,41 @@
-import { useEffect, useRef, useState } from "react";
-import { AppState, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from "react-native";
 import { StatusBar } from "expo-status-bar";
+import { useFocusEffect } from "@react-navigation/native";
 import { useRecorder } from "@/hooks/useRecorder";
 import { formatDuration } from "@/utils/formatDuration";
+import { getSplitIntervalMs } from "@/utils/settingsStore";
+import { getRecentDecibels } from "@/utils/decibelBuffer";
+import { downsample } from "@/utils/csvParser";
+import type { DecibelPoint } from "@/utils/csvParser";
+import LiveDbGraph from "@/components/LiveDbGraph";
 import colors from "@/theme/colors";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { RootStackParamList } from "../../App";
 
+const LIVE_WINDOW_MS = 60_000; // 1 minute
+const GRAPH_HEIGHT = 160;
+
 type Props = NativeStackScreenProps<RootStackParamList, "Home">;
 
-function normalizeDbSpl(dbSpl: number): number {
-  return Math.max(0, Math.min(1, dbSpl / 130));
-}
-
 export default function HomeScreen({ navigation }: Props) {
+  const { width: screenWidth } = useWindowDimensions();
+  const [splitIntervalMs, setSplitIntervalMs] = useState<number | null>(
+    getSplitIntervalMs
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      setSplitIntervalMs(getSplitIntervalMs());
+    }, [])
+  );
+
   const {
     status,
     dbSpl,
@@ -22,26 +44,47 @@ export default function HomeScreen({ navigation }: Props) {
     savedFiles,
     start,
     stop,
-  } = useRecorder();
+  } = useRecorder(splitIntervalMs);
 
-  const appState = useRef(AppState.currentState);
-  const [appStateLabel, setAppStateLabel] = useState(AppState.currentState);
+  const [livePoints, setLivePoints] = useState<DecibelPoint[]>([]);
+  const timerRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
   useEffect(() => {
-    const subscription = AppState.addEventListener("change", (nextAppState) => {
-      appState.current = nextAppState;
-      setAppStateLabel(nextAppState);
-    });
-    return () => subscription.remove();
-  }, []);
+    if (!isRecording) {
+      if (timerRef.current) clearInterval(timerRef.current);
+      return;
+    }
 
-  const barWidth = normalizeDbSpl(dbSpl) * 100;
+    const graphWidth = screenWidth - 48; // paddingHorizontal 24 * 2
+    const maxPoints = Math.floor(graphWidth / 2);
+
+    const poll = () => {
+      const rows = getRecentDecibels(LIVE_WINDOW_MS);
+      const points: DecibelPoint[] = rows.map((r) => ({
+        timestamp: r.ts,
+        offsetMs: r.offset_ms,
+        dbSpl: Math.max(0, r.db + 100),
+      }));
+      setLivePoints(downsample(points, maxPoints));
+    };
+
+    poll();
+    timerRef.current = setInterval(poll, 1000);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [isRecording, screenWidth]);
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Recording PoC</Text>
-
-      <Text style={styles.appState}>AppState: {appStateLabel}</Text>
+      <Text
+        style={[
+          styles.statusLabel,
+          isRecording ? styles.statusRecording : styles.statusIdle,
+        ]}
+      >
+        {isRecording ? "● 録音中" : "■ 停止中"}
+      </Text>
 
       {status === "permission_denied" && (
         <Text style={styles.warning}>
@@ -52,12 +95,20 @@ export default function HomeScreen({ navigation }: Props) {
       <View style={styles.meterContainer}>
         <Text style={styles.dbValue}>{dbSpl.toFixed(1)} dB</Text>
         <Text style={styles.dbLabel}>approx. SPL</Text>
-        <View style={styles.barBackground}>
-          <View style={[styles.barFill, { width: `${barWidth}%` }]} />
-        </View>
+        <LiveDbGraph
+          points={livePoints}
+          windowMs={LIVE_WINDOW_MS}
+          viewportWidth={screenWidth - 48}
+          height={GRAPH_HEIGHT}
+        />
       </View>
 
-      <Text style={styles.duration}>{formatDuration(totalDurationMillis)}</Text>
+      <Text style={styles.duration}>
+        {formatDuration(totalDurationMillis)}
+        {savedFiles.length > 0
+          ? ` (${savedFiles.length} file${savedFiles.length !== 1 ? "s" : ""})`
+          : ""}
+      </Text>
 
       <TouchableOpacity
         style={[styles.button, isRecording && styles.buttonStop]}
@@ -67,12 +118,6 @@ export default function HomeScreen({ navigation }: Props) {
           {isRecording ? "停止" : "録音開始"}
         </Text>
       </TouchableOpacity>
-
-      {savedFiles.length > 0 && (
-        <Text style={styles.savedCount}>
-          {savedFiles.length} file{savedFiles.length !== 1 ? "s" : ""} saved
-        </Text>
-      )}
 
       <TouchableOpacity
         style={styles.navButton}
@@ -93,12 +138,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     paddingHorizontal: 24,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: "bold",
-    marginBottom: 32,
-    color: colors.textPrimary,
   },
   warning: {
     color: colors.accentRed,
@@ -123,18 +162,6 @@ const styles = StyleSheet.create({
     color: colors.textTertiary,
     marginBottom: 12,
   },
-  barBackground: {
-    width: "100%",
-    height: 20,
-    backgroundColor: colors.borderStrong,
-    borderRadius: 10,
-    overflow: "hidden",
-  },
-  barFill: {
-    height: "100%",
-    backgroundColor: colors.accentGreen,
-    borderRadius: 10,
-  },
   duration: {
     fontSize: 20,
     fontVariant: ["tabular-nums"],
@@ -146,7 +173,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 32,
     paddingVertical: 14,
     borderRadius: 12,
-    marginBottom: 16,
+    marginBottom: 24,
   },
   buttonStop: {
     backgroundColor: colors.accentRed,
@@ -155,17 +182,6 @@ const styles = StyleSheet.create({
     color: colors.onAccent,
     fontSize: 18,
     fontWeight: "bold",
-  },
-  savedCount: {
-    fontSize: 12,
-    color: colors.textTertiary,
-    textAlign: "center",
-    marginBottom: 16,
-  },
-  appState: {
-    fontSize: 14,
-    color: colors.textTertiary,
-    marginBottom: 16,
   },
   navButton: {
     backgroundColor: colors.accentPurple,
@@ -178,5 +194,16 @@ const styles = StyleSheet.create({
     color: colors.onAccent,
     fontSize: 16,
     fontWeight: "bold",
+  },
+  statusLabel: {
+    fontSize: 16,
+    fontWeight: "bold",
+    marginBottom: 8,
+  },
+  statusRecording: {
+    color: colors.accentRed,
+  },
+  statusIdle: {
+    color: colors.textSecondary,
   },
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+import colors from "@/theme/colors";
+import {
+  SPLIT_INTERVAL_OPTIONS,
+  getSplitIntervalMs,
+  setSplitIntervalMs,
+} from "@/utils/settingsStore";
+import { getTotalStorageBytes, formatBytes } from "@/utils/storageUsage";
+
+export default function SettingsScreen() {
+  const [splitInterval, setSplitInterval] = useState<number | null>(
+    getSplitIntervalMs
+  );
+  const [storageBytes, setStorageBytes] = useState(0);
+
+  useFocusEffect(
+    useCallback(() => {
+      setStorageBytes(getTotalStorageBytes());
+    }, [])
+  );
+
+  const handleSelectInterval = (value: number | null) => {
+    setSplitInterval(value);
+    setSplitIntervalMs(value);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.sectionTitle}>分割間隔</Text>
+      <View style={styles.chipRow}>
+        {SPLIT_INTERVAL_OPTIONS.map((opt) => {
+          const selected =
+            splitInterval === opt.value;
+          return (
+            <TouchableOpacity
+              key={opt.label}
+              style={[styles.chip, selected && styles.chipSelected]}
+              onPress={() => handleSelectInterval(opt.value)}
+            >
+              <Text
+                style={[
+                  styles.chipText,
+                  selected && styles.chipTextSelected,
+                ]}
+              >
+                {opt.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      <Text style={styles.sectionTitle}>ストレージ使用量</Text>
+      <Text style={styles.storageValue}>{formatBytes(storageBytes)}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgPrimary,
+    padding: 24,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: colors.textSecondary,
+    marginBottom: 12,
+    marginTop: 16,
+  },
+  chipRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  chip: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: colors.bgSecondary,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+  },
+  chipSelected: {
+    backgroundColor: colors.accentBlue,
+    borderColor: colors.accentBlue,
+  },
+  chipText: {
+    fontSize: 14,
+    color: colors.textSecondary,
+  },
+  chipTextSelected: {
+    color: colors.onAccent,
+    fontWeight: "bold",
+  },
+  storageValue: {
+    fontSize: 24,
+    fontWeight: "bold",
+    color: colors.textPrimary,
+  },
+});

--- a/src/utils/decibelBuffer.ts
+++ b/src/utils/decibelBuffer.ts
@@ -47,6 +47,16 @@ export function deleteDecibelRows(fromIso: string, toIso: string): void {
   );
 }
 
+export function getRecentDecibels(
+  limitMs: number
+): { offset_ms: number; db: number; ts: string }[] {
+  const sinceIso = new Date(Date.now() - limitMs).toISOString();
+  return db.getAllSync<{ offset_ms: number; db: number; ts: string }>(
+    "SELECT ts, offset_ms, db FROM decibel_log WHERE ts >= ? ORDER BY ts",
+    sinceIso
+  );
+}
+
 export function clearAllDecibelRows(): void {
   db.runSync("DELETE FROM decibel_log");
 }

--- a/src/utils/settingsStore.ts
+++ b/src/utils/settingsStore.ts
@@ -1,0 +1,45 @@
+import { openDatabaseSync } from "expo-sqlite";
+
+const db = openDatabaseSync("decibel_buffer.db");
+
+db.execSync(
+  `CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  )`
+);
+
+const KEY_SPLIT_INTERVAL = "split_interval_ms";
+
+export type SplitIntervalOption = {
+  label: string;
+  value: number | null;
+};
+
+export const SPLIT_INTERVAL_OPTIONS: SplitIntervalOption[] = [
+  { label: "1時間", value: 3_600_000 },
+  { label: "3時間", value: 10_800_000 },
+  { label: "6時間", value: 21_600_000 },
+  { label: "12時間", value: 43_200_000 },
+  { label: "OFF", value: null },
+];
+
+const DEFAULT_SPLIT_INTERVAL_MS = 21_600_000; // 6 hours
+
+export function getSplitIntervalMs(): number | null {
+  const row = db.getFirstSync<{ value: string }>(
+    "SELECT value FROM settings WHERE key = ?",
+    KEY_SPLIT_INTERVAL
+  );
+  if (row == null) return DEFAULT_SPLIT_INTERVAL_MS;
+  if (row.value === "null") return null;
+  return Number(row.value);
+}
+
+export function setSplitIntervalMs(value: number | null): void {
+  db.runSync(
+    "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+    KEY_SPLIT_INTERVAL,
+    String(value)
+  );
+}

--- a/src/utils/storageUsage.ts
+++ b/src/utils/storageUsage.ts
@@ -1,0 +1,25 @@
+import { File, Directory, Paths } from "expo-file-system/next";
+
+const RECORDINGS_DIR = "recordings";
+
+export function getTotalStorageBytes(): number {
+  const dir = new Directory(Paths.document, RECORDINGS_DIR);
+  if (!dir.exists) return 0;
+
+  let total = 0;
+  const entries = dir.list();
+  for (const entry of entries) {
+    if (entry instanceof File) {
+      total += entry.size ?? 0;
+    }
+  }
+  return total;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}


### PR DESCRIPTION
## Summary
- 録音画面のバーメーターをリアルタイムdBグラフ（直近1分）に置き換え
- `LiveDbGraph` コンポーネントを新規作成（SVGベース、15秒間隔グリッド）
- `decibelBuffer` に `getRecentDecibels()` クエリを追加し、1秒ポーリングでグラフ更新
- 設定画面を追加し、ファイル分割間隔を変更可能に
- `useRecorder` を分割間隔の外部指定に対応

## Test plan
- [x] 録音中にリアルタイムでグラフが右から左へ流れることを確認
- [x] 停止中はグラフが更新されないことを確認
- [x] 1分以上録音するとグラフが直近1分にクリップされることを確認
- [x] 設定画面でファイル分割間隔を変更できることを確認
- [x] `tsc --noEmit` パス済み

close #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)