### PR TITLE
長時間録音時のクラッシュ・フリーズ修正とバックグラウンド分割対応

### DIFF
--- a/src/components/DbGraph.tsx
+++ b/src/components/DbGraph.tsx
@@ -69,7 +69,13 @@ export default function DbGraph({
 
   // 1 minute = plotWidth
   const durationMin = Math.max(durationMs / 60000, 1);
-  const totalPlotWidth = plotWidth * durationMin;
+
+  // Android Canvas bitmap limit ≈ 100MB; keep well under to avoid OOM
+  const MAX_BITMAP_BYTES = 10_000_000; // 10MB — conservative for low-spec devices
+  const maxPlotWidth = Math.floor(MAX_BITMAP_BYTES / (height * 4)) - MARGIN_LEFT;
+
+  const rawTotalPlotWidth = plotWidth * durationMin;
+  const totalPlotWidth = Math.min(rawTotalPlotWidth, maxPlotWidth);
   const totalSvgWidth = MARGIN_LEFT + totalPlotWidth;
 
   // Convert dB value to Y coordinate within the plot area
@@ -112,8 +118,8 @@ export default function DbGraph({
 
   // --- Vertical grid lines (time) ---
   const timeGridLines = useMemo(() => {
-    // ms per viewport (plotWidth pixels)
-    const msPerViewport = durationMs / durationMin;
+    // ms per viewport (plotWidth pixels) — based on actual (possibly capped) scale
+    const msPerViewport = (plotWidth / totalPlotWidth) * durationMs;
     const interval = pickTimeInterval(msPerViewport);
     const lines: { ms: number; x: number }[] = [];
     for (let t = 0; t <= durationMs; t += interval) {

--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -14,7 +14,7 @@ import {
   writeDecibelCsv,
 } from "@/utils/fileManager";
 import {
-  insertDecibel,
+  insertDecibelBatch,
   exportDecibelCsv,
   deleteDecibelRows,
   clearAllDecibelRows,
@@ -46,6 +46,7 @@ const RECORDING_OPTIONS = {
 };
 
 const POLLING_INTERVAL_MS = 100;
+const FLUSH_INTERVAL_MS = 2000;
 
 // Approximate offset to convert dBFS to dB SPL.
 // This is a rough estimate; accurate conversion requires per-device calibration.
@@ -82,6 +83,15 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
   const segmentStartRef = useRef<number>(0);
   // ISO timestamp when the current segment started (for SQLite range queries)
   const segmentStartIsoRef = useRef<string>("");
+  // Memory buffer for batched SQLite inserts
+  const pendingInserts = useRef<{ ts: string; offsetMs: number; db: number }[]>(
+    []
+  );
+  const flushRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Refs for background-safe split: polling callback can access latest values
+  const splitIntervalMsRef = useRef(splitIntervalMs);
+  splitIntervalMsRef.current = splitIntervalMs;
+  const splitRecordingRef = useRef<() => void>(() => {});
 
   // Set audio mode early so the native recorder inherits allowsBackgroundRecording
   useEffect(() => {
@@ -92,6 +102,25 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
       allowsBackgroundRecording: true,
     });
   }, []);
+
+  const flushPending = useCallback(() => {
+    if (pendingInserts.current.length > 0) {
+      insertDecibelBatch(pendingInserts.current);
+      pendingInserts.current = [];
+    }
+  }, []);
+
+  const stopFlushing = useCallback(() => {
+    if (flushRef.current != null) {
+      clearInterval(flushRef.current);
+      flushRef.current = null;
+    }
+  }, []);
+
+  const startFlushing = useCallback(() => {
+    stopFlushing();
+    flushRef.current = setInterval(flushPending, FLUSH_INTERVAL_MS);
+  }, [stopFlushing, flushPending]);
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current != null) {
@@ -110,11 +139,23 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
           const newState: RecorderState = recorder.getStatus();
           setMetering(newState.metering);
           setIsRecording(newState.isRecording);
-          setSegmentElapsedMillis(now - segmentStartRef.current);
+          const elapsed = now - segmentStartRef.current;
+          setSegmentElapsedMillis(elapsed);
           if (newState.metering != null) {
-            const isoString = new Date(now).toISOString();
-            const offsetMs = now - segmentStartRef.current;
-            insertDecibel(isoString, offsetMs, newState.metering);
+            pendingInserts.current.push({
+              ts: new Date(now).toISOString(),
+              offsetMs: elapsed,
+              db: newState.metering,
+            });
+          }
+          // Split check — runs in background too (via react-native-background-actions)
+          const interval = splitIntervalMsRef.current;
+          if (
+            !isSplittingRef.current &&
+            interval !== null &&
+            elapsed >= interval
+          ) {
+            splitRecordingRef.current();
           }
         } catch {
           // Polling may fail if recorder was released
@@ -135,6 +176,8 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
     }
 
     stopPolling();
+    stopFlushing();
+    flushPending();
 
     const segmentDuration = Date.now() - segmentStartRef.current;
     const fromIso = segmentStartIsoRef.current;
@@ -151,6 +194,7 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
     segmentStartRef.current = Date.now();
     segmentStartIsoRef.current = new Date().toISOString();
     startPolling(newRecorder);
+    startFlushing();
 
     // Move the old file and export CSV
     if (oldUri) {
@@ -166,24 +210,14 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
     setCompletedDurationMillis((prev) => prev + segmentDuration);
     setSegmentElapsedMillis(0);
     isSplittingRef.current = false;
-  }, [stopPolling, startPolling]);
-
-  // Check if split is needed (wall-clock based)
-  useEffect(() => {
-    if (
-      isRecording &&
-      !isSplittingRef.current &&
-      splitIntervalMs !== null &&
-      segmentElapsedMillis >= splitIntervalMs
-    ) {
-      splitRecording();
-    }
-  }, [segmentElapsedMillis, isRecording, splitIntervalMs, splitRecording]);
+  }, [stopPolling, startPolling, stopFlushing, startFlushing, flushPending]);
+  splitRecordingRef.current = splitRecording;
 
   // Restart polling and refresh state when returning to foreground.
   // setInterval may stop firing while the app is in the background on iOS;
   // we recreate it on resume so the UI keeps updating.
   useEffect(() => {
+    let resumeTimeoutId: ReturnType<typeof setTimeout> | null = null;
     const subscription = AppState.addEventListener("change", (nextAppState) => {
       const recorder = recorderRef.current;
       if (nextAppState === "active" && recorder) {
@@ -195,18 +229,27 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
         } catch {
           // Recorder may have been released
         }
-        startPolling(recorder);
+        // Delay polling restart to let UI render first
+        resumeTimeoutId = setTimeout(() => {
+          startPolling(recorder);
+          startFlushing();
+        }, 300);
       }
     });
-    return () => subscription.remove();
-  }, [startPolling]);
+    return () => {
+      if (resumeTimeoutId) clearTimeout(resumeTimeoutId);
+      subscription.remove();
+    };
+  }, [startPolling, startFlushing]);
 
   // Clean up on unmount
   useEffect(() => {
     return () => {
       stopPolling();
+      stopFlushing();
+      flushPending();
     };
-  }, [stopPolling]);
+  }, [stopPolling, stopFlushing, flushPending]);
 
   const start = useCallback(async () => {
     const { granted } = await requestRecordingPermissionsAsync();
@@ -225,17 +268,21 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
     await startBackgroundTask();
 
     clearAllDecibelRows();
+    pendingInserts.current = [];
     segmentStartRef.current = Date.now();
     segmentStartIsoRef.current = new Date().toISOString();
     setSavedFiles([]);
     setCompletedDurationMillis(0);
     setSegmentElapsedMillis(0);
     startPolling(recorder);
+    startFlushing();
     setStatus("recording");
-  }, [startPolling]);
+  }, [startPolling, startFlushing]);
 
   const stop = useCallback(async () => {
     stopPolling();
+    stopFlushing();
+    flushPending();
 
     const recorder = recorderRef.current;
     if (recorder) {
@@ -262,7 +309,7 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
     setIsRecording(false);
     setSegmentElapsedMillis(0);
     setStatus("idle");
-  }, [stopPolling]);
+  }, [stopPolling, stopFlushing, flushPending]);
 
   const meteringDbfs = metering ?? -160;
   const dbSpl = Math.max(0, meteringDbfs + DBFS_TO_SPL_OFFSET);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  AppState,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -48,6 +49,19 @@ export default function HomeScreen({ navigation }: Props) {
 
   const [livePoints, setLivePoints] = useState<DecibelPoint[]>([]);
   const timerRef = useRef<ReturnType<typeof setInterval>>(undefined);
+  // Track when the graph was last reset (app resume) to avoid querying old data
+  const graphOriginRef = useRef<number>(Date.now());
+
+  // Reset graph on foreground resume to avoid heavy SQLite queries
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (next) => {
+      if (next === "active") {
+        graphOriginRef.current = Date.now();
+        setLivePoints([]);
+      }
+    });
+    return () => subscription.remove();
+  }, []);
 
   useEffect(() => {
     if (!isRecording) {
@@ -59,7 +73,11 @@ export default function HomeScreen({ navigation }: Props) {
     const maxPoints = Math.floor(graphWidth / 2);
 
     const poll = () => {
-      const rows = getRecentDecibels(LIVE_WINDOW_MS);
+      // Only query data since the graph was reset (or up to LIVE_WINDOW_MS)
+      const elapsed = Date.now() - graphOriginRef.current;
+      const windowMs = Math.min(LIVE_WINDOW_MS, elapsed);
+      if (windowMs < 500) return; // too early, skip
+      const rows = getRecentDecibels(windowMs);
       const points: DecibelPoint[] = rows.map((r) => ({
         timestamp: r.ts,
         offsetMs: r.offset_ms,
@@ -68,9 +86,14 @@ export default function HomeScreen({ navigation }: Props) {
       setLivePoints(downsample(points, maxPoints));
     };
 
-    poll();
-    timerRef.current = setInterval(poll, 1000);
+    // Delay start to avoid blocking UI on sleep resume
+    const delayId = setTimeout(() => {
+      poll();
+      timerRef.current = setInterval(poll, 1000);
+    }, 500);
+
     return () => {
+      clearTimeout(delayId);
       if (timerRef.current) clearInterval(timerRef.current);
     };
   }, [isRecording, screenWidth]);

--- a/src/screens/PlaybackScreen.tsx
+++ b/src/screens/PlaybackScreen.tsx
@@ -29,7 +29,8 @@ export default function PlaybackScreen({ route }: Props) {
 
   // Downsample to half of total graph width (1min = viewportWidth)
   const durationMin = Math.max(durationMs / 60000, 1);
-  const totalGraphWidth = viewportWidth * durationMin;
+  const MAX_GRAPH_WIDTH = 10_000;
+  const totalGraphWidth = Math.min(viewportWidth * durationMin, MAX_GRAPH_WIDTH);
   const maxPoints = Math.max(300, Math.round(totalGraphWidth / 2));
 
   const playbackData = usePlaybackData(uri, maxPoints);

--- a/src/utils/decibelBuffer.ts
+++ b/src/utils/decibelBuffer.ts
@@ -11,7 +11,27 @@ db.execSync(
     db REAL NOT NULL
   )`
 );
+db.execSync(
+  "CREATE INDEX IF NOT EXISTS idx_decibel_log_ts ON decibel_log(ts)"
+);
 
+export function insertDecibelBatch(
+  rows: { ts: string; offsetMs: number; db: number }[]
+): void {
+  if (rows.length === 0) return;
+  db.withTransactionSync(() => {
+    for (const row of rows) {
+      db.runSync(
+        "INSERT INTO decibel_log (ts, offset_ms, db) VALUES (?, ?, ?)",
+        row.ts,
+        row.offsetMs,
+        row.db
+      );
+    }
+  });
+}
+
+/** @deprecated Use insertDecibelBatch for better performance */
 export function insertDecibel(
   timestampIso: string,
   offsetMs: number,

--- a/src/utils/settingsStore.ts
+++ b/src/utils/settingsStore.ts
@@ -17,6 +17,8 @@ export type SplitIntervalOption = {
 };
 
 export const SPLIT_INTERVAL_OPTIONS: SplitIntervalOption[] = [
+  { label: "30秒", value: 30_000 },
+  { label: "30分", value: 1_800_000 },
   { label: "1時間", value: 3_600_000 },
   { label: "3時間", value: 10_800_000 },
   { label: "6時間", value: 21_600_000 },


### PR DESCRIPTION
## Summary
- **再生画面クラッシュ防止**: DbGraph SVG幅を10MBビットマップ上限でキャップし、Android Canvas `trying to draw too large bitmap` クラッシュを防止。時間ラベルの間隔もキャップ後のスケールに合わせて調整
- **再生画面ポイント数制限**: PlaybackScreenの`maxPoints`もキャップ後の幅に合わせて制限し、不必要なパースを回避
- **復帰時フリーズ防止**: バックグラウンド復帰時にライブグラフをリセットし、SQLiteクエリ範囲を復帰時点からに絞ることで重いクエリを回避
- **バックグラウンド分割対応**: ファイル分割チェックを`useEffect`からポーリングコールバック内に移動し、`react-native-background-actions`でJSスレッドが生きている限りバックグラウンドでも分割が発動するように
- **SQLite書き込み最適化**: `insertDecibel`(毎回INSERT)から`insertDecibelBatch`(2秒ごとバッチINSERT)に変更、tsカラムにインデックス追加
- **分割間隔オプション追加**: 設定画面に30秒（デバッグ用）・30分を追加

## Test plan
- [ ] 6時間以上の録音ファイルを再生画面で開いてもクラッシュしないこと
- [ ] グラフの時間ラベルが適切な間隔で表示されること
- [ ] グラフのスクロール・カーソル追従・タップシークが正常動作すること
- [ ] 1時間以上のバックグラウンド復帰でフリーズしないこと
- [ ] 分割間隔30秒に設定してバックグラウンドで分割が発動することを確認
- [ ] 設定画面で30秒・30分の選択肢が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)