### PR TITLE
exportDecibelCsv の非同期化で停止/split時のUIフリーズを防止

### DIFF
--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -196,15 +196,16 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
     startPolling(newRecorder);
     startFlushing();
 
-    // Move the old file and export CSV
+    // Move the old file and export CSV — runs async after recording resumes
     if (oldUri) {
       const audioFilename = moveRecording(oldUri);
       setSavedFiles((prev) => [...prev, getRecordingUri(audioFilename)]);
 
-      const csvContent = exportDecibelCsv(fromIso, toIso);
-      writeDecibelCsv(csvContent, audioFilename);
-      deleteDecibelRows(fromIso, toIso);
-
+      // Non-blocking: CSV export + cleanup runs in background
+      exportDecibelCsv(fromIso, toIso).then((csvContent) => {
+        writeDecibelCsv(csvContent, audioFilename);
+        deleteDecibelRows(fromIso, toIso);
+      });
     }
 
     setCompletedDurationMillis((prev) => prev + segmentDuration);
@@ -296,9 +297,9 @@ export function useRecorder(splitIntervalMs: number | null = 21_600_000) {
         const audioFilename = moveRecording(uri);
         setSavedFiles((prev) => [...prev, getRecordingUri(audioFilename)]);
 
-        const csvContent = exportDecibelCsv(fromIso, toIso);
+        const csvContent = await exportDecibelCsv(fromIso, toIso);
         writeDecibelCsv(csvContent, audioFilename);
-        deleteDecibelRows(fromIso, toIso);
+        await deleteDecibelRows(fromIso, toIso);
       }
       setCompletedDurationMillis((prev) => prev + segmentDuration);
       recorderRef.current = null;

--- a/src/utils/decibelBuffer.ts
+++ b/src/utils/decibelBuffer.ts
@@ -45,8 +45,8 @@ export function insertDecibel(
   );
 }
 
-export function exportDecibelCsv(fromIso: string, toIso: string): string {
-  const rows = db.getAllSync<{ ts: string; offset_ms: number; db: number }>(
+export async function exportDecibelCsv(fromIso: string, toIso: string): Promise<string> {
+  const rows = await db.getAllAsync<{ ts: string; offset_ms: number; db: number }>(
     "SELECT ts, offset_ms, db FROM decibel_log WHERE ts >= ? AND ts <= ? ORDER BY ts",
     fromIso,
     toIso
@@ -59,8 +59,8 @@ export function exportDecibelCsv(fromIso: string, toIso: string): string {
   return lines.join("\n") + "\n";
 }
 
-export function deleteDecibelRows(fromIso: string, toIso: string): void {
-  db.runSync(
+export async function deleteDecibelRows(fromIso: string, toIso: string): Promise<void> {
+  await db.runAsync(
     "DELETE FROM decibel_log WHERE ts >= ? AND ts <= ?",
     fromIso,
     toIso


### PR DESCRIPTION
## Summary
- `exportDecibelCsv` / `deleteDecibelRows` を `getAllAsync` / `runAsync` に置き換え、JSスレッドのブロッキングを解消
- split時はCSV export + deleteを録音再開後にバックグラウンドで `.then()` 実行し、録音の空白時間を最小化
- stop時は `await` で完了を保証しつつ非同期化

## Test plan
- [ ] `tsc --noEmit` パス
- [x] 30秒分割設定で録音 → split発動時にUIがフリーズしないこと
- [x] 停止ボタン押下後、CSVファイルが正しく保存されていること
- [x] 分割後の新しい録音が途切れなく開始されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)