### PR TITLE
録音ファイルをセッション/セグメントのディレクトリ構造で管理

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import HomeScreen from "@/screens/HomeScreen";
 import RecordingsScreen from "@/screens/RecordingsScreen";
 import PlaybackScreen from "@/screens/PlaybackScreen";
 import SettingsScreen from "@/screens/SettingsScreen";
+import DebugLogScreen from "@/screens/DebugLogScreen";
 import colors from "@/theme/colors";
 import { configureGoogleSignIn } from "@/services/googleAuth";
 
@@ -15,6 +16,7 @@ export type RootStackParamList = {
   Recordings: undefined;
   Playback: { uri: string; name: string };
   Settings: undefined;
+  DebugLog: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -49,6 +51,11 @@ const App = () => {
         />
         <Stack.Screen name="Playback" component={PlaybackScreen} options={{ title: "再生" }} />
         <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: "設定" }} />
+        <Stack.Screen
+          name="DebugLog"
+          component={DebugLogScreen}
+          options={{ title: "デバッグログ" }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/hooks/usePlaybackData.ts
+++ b/src/hooks/usePlaybackData.ts
@@ -21,7 +21,7 @@ export const usePlaybackData = (audioUri: string, maxPoints: number): PlaybackDa
 
     async function load() {
       try {
-        const csvUri = audioUri.replace(/\.m4a$/, ".csv");
+        const csvUri = audioUri.replace(/audio\.m4a$/, "decibel.csv");
         const csvFile = new File(csvUri);
         if (!csvFile.exists) {
           if (!cancelled)

--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -9,7 +9,13 @@ import {
 } from "expo-audio";
 import type { RecorderState } from "expo-audio";
 import { requireNativeModule } from "expo-modules-core";
-import { moveRecording, getRecordingUri, writeDecibelCsv } from "@/utils/fileManager";
+import {
+  moveRecording,
+  getAudioUri,
+  getSegmentPath,
+  writeDecibelCsv,
+  generateSessionId,
+} from "@/utils/fileManager";
 import {
   insertDecibelBatch,
   exportDecibelCsv,
@@ -79,6 +85,8 @@ export const useRecorder = (splitIntervalMs: number | null = 21_600_000) => {
   const segmentStartRef = useRef<number>(0);
   // ISO timestamp when the current segment started (for SQLite range queries)
   const segmentStartIsoRef = useRef<string>("");
+  // Session ID for the current recording session (persists across splits)
+  const sessionIdRef = useRef<string>("");
   // Memory buffer for batched SQLite inserts
   const pendingInserts = useRef<{ ts: string; offsetMs: number; db: number }[]>([]);
   const flushRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -173,6 +181,7 @@ export const useRecorder = (splitIntervalMs: number | null = 21_600_000) => {
     stopFlushing();
     flushPending();
 
+    const oldSegmentStartedAt = new Date(segmentStartRef.current);
     const segmentDuration = Date.now() - segmentStartRef.current;
     const fromIso = segmentStartIsoRef.current;
     const toIso = new Date().toISOString();
@@ -192,14 +201,16 @@ export const useRecorder = (splitIntervalMs: number | null = 21_600_000) => {
 
     // Move the old file and export CSV — runs async after recording resumes
     if (oldUri) {
-      const audioFilename = moveRecording(oldUri);
-      setSavedFiles((prev) => [...prev, getRecordingUri(audioFilename)]);
+      const currentSessionId = sessionIdRef.current;
+      const { segmentId } = moveRecording(oldUri, currentSessionId, oldSegmentStartedAt);
+      setSavedFiles((prev) => [...prev, getAudioUri(currentSessionId, segmentId)]);
 
       // Non-blocking: CSV export + cleanup + upload trigger runs in background
+      const segmentPath = getSegmentPath(currentSessionId, segmentId);
       exportDecibelCsv(fromIso, toIso).then((csvContent) => {
-        writeDecibelCsv(csvContent, audioFilename);
+        writeDecibelCsv(csvContent, currentSessionId, segmentId);
         deleteDecibelRows(fromIso, toIso);
-        triggerUploadAfterSplit(audioFilename);
+        triggerUploadAfterSplit(segmentPath);
       });
     }
 
@@ -273,6 +284,7 @@ export const useRecorder = (splitIntervalMs: number | null = 21_600_000) => {
 
     clearAllDecibelRows();
     pendingInserts.current = [];
+    sessionIdRef.current = generateSessionId();
     segmentStartRef.current = Date.now();
     segmentStartIsoRef.current = new Date().toISOString();
     setSavedFiles([]);
@@ -290,6 +302,7 @@ export const useRecorder = (splitIntervalMs: number | null = 21_600_000) => {
 
     const recorder = recorderRef.current;
     if (recorder) {
+      const segStartedAt = new Date(segmentStartRef.current);
       const segmentDuration = Date.now() - segmentStartRef.current;
       const fromIso = segmentStartIsoRef.current;
       const toIso = new Date().toISOString();
@@ -297,13 +310,14 @@ export const useRecorder = (splitIntervalMs: number | null = 21_600_000) => {
       await recorder.stop();
       const uri = recorder.uri;
       if (uri) {
-        const audioFilename = moveRecording(uri);
-        setSavedFiles((prev) => [...prev, getRecordingUri(audioFilename)]);
+        const currentSessionId = sessionIdRef.current;
+        const { segmentId } = moveRecording(uri, currentSessionId, segStartedAt);
+        setSavedFiles((prev) => [...prev, getAudioUri(currentSessionId, segmentId)]);
 
         const csvContent = await exportDecibelCsv(fromIso, toIso);
-        writeDecibelCsv(csvContent, audioFilename);
+        writeDecibelCsv(csvContent, currentSessionId, segmentId);
         await deleteDecibelRows(fromIso, toIso);
-        triggerUploadAfterSplit(audioFilename);
+        triggerUploadAfterSplit(getSegmentPath(currentSessionId, segmentId));
       }
       setCompletedDurationMillis((prev) => prev + segmentDuration);
       recorderRef.current = null;

--- a/src/screens/DebugLogScreen.tsx
+++ b/src/screens/DebugLogScreen.tsx
@@ -1,17 +1,25 @@
 import { useCallback, useState } from "react";
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import { readLog, clearLog } from "@/utils/debugLog";
+import { getDebugLogEnabled, setDebugLogEnabled } from "@/utils/settingsStore";
 import colors from "@/theme/colors";
 
 const DebugLogScreen = () => {
   const [logText, setLogText] = useState("");
+  const [enabled, setEnabled] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
       setLogText(readLog());
+      setEnabled(getDebugLogEnabled());
     }, []),
   );
+
+  const handleToggle = (value: boolean) => {
+    setEnabled(value);
+    setDebugLogEnabled(value);
+  };
 
   const handleClear = () => {
     clearLog();
@@ -25,6 +33,11 @@ const DebugLogScreen = () => {
   return (
     <View style={styles.container}>
       <View style={styles.toolbar}>
+        <View style={styles.switchRow}>
+          <Text style={styles.switchLabel}>ログ有効</Text>
+          <Switch value={enabled} onValueChange={handleToggle} />
+        </View>
+        <View style={styles.toolbarSpacer} />
         <TouchableOpacity style={styles.refreshButton} onPress={handleRefresh}>
           <Text style={styles.buttonText}>更新</Text>
         </TouchableOpacity>
@@ -50,12 +63,24 @@ const styles = StyleSheet.create({
   },
   toolbar: {
     flexDirection: "row",
-    justifyContent: "flex-end",
+    alignItems: "center",
     paddingHorizontal: 16,
     paddingVertical: 12,
     gap: 8,
     borderBottomWidth: 1,
     borderBottomColor: colors.borderStrong,
+  },
+  switchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  switchLabel: {
+    fontSize: 14,
+    color: colors.textPrimary,
+  },
+  toolbarSpacer: {
+    flex: 1,
   },
   refreshButton: {
     backgroundColor: colors.accentBlue,

--- a/src/screens/DebugLogScreen.tsx
+++ b/src/screens/DebugLogScreen.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useState } from "react";
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+import { readLog, clearLog } from "@/utils/debugLog";
+import colors from "@/theme/colors";
+
+const DebugLogScreen = () => {
+  const [logText, setLogText] = useState("");
+
+  useFocusEffect(
+    useCallback(() => {
+      setLogText(readLog());
+    }, []),
+  );
+
+  const handleClear = () => {
+    clearLog();
+    setLogText("(クリア済み)");
+  };
+
+  const handleRefresh = () => {
+    setLogText(readLog());
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.toolbar}>
+        <TouchableOpacity style={styles.refreshButton} onPress={handleRefresh}>
+          <Text style={styles.buttonText}>更新</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.clearButton} onPress={handleClear}>
+          <Text style={styles.buttonText}>クリア</Text>
+        </TouchableOpacity>
+      </View>
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.logText} selectable>
+          {logText}
+        </Text>
+      </ScrollView>
+    </View>
+  );
+};
+
+export default DebugLogScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgPrimary,
+  },
+  toolbar: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderStrong,
+  },
+  refreshButton: {
+    backgroundColor: colors.accentBlue,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  clearButton: {
+    backgroundColor: colors.accentRed,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: colors.onAccent,
+    fontSize: 14,
+    fontWeight: "bold",
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+  },
+  logText: {
+    fontSize: 11,
+    color: colors.textSecondary,
+    fontFamily: "monospace",
+    lineHeight: 18,
+  },
+});

--- a/src/screens/RecordingsScreen.tsx
+++ b/src/screens/RecordingsScreen.tsx
@@ -1,25 +1,47 @@
 import { useCallback, useState } from "react";
-import { Alert, FlatList, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Alert, SectionList, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { RootStackParamList } from "../../App";
 import {
-  listRecordings,
-  deleteRecording,
+  listRecordingSessions,
+  deleteSegment,
   deleteAllRecordings,
-  type RecordingFile,
+  getSegmentPath,
+  type SegmentFile,
 } from "@/utils/fileManager";
 import colors from "@/theme/colors";
 import { uploadManual, syncDriveStatus } from "@/services/uploadManager";
-import { getUploadStatusForFile, type FileUploadStatus } from "@/services/uploadQueue";
+import { getAllUploadStatuses, type FileUploadStatus } from "@/services/uploadQueue";
 import { isSignedIn } from "@/services/googleAuth";
 
 type Props = NativeStackScreenProps<RootStackParamList, "Recordings">;
+
+type SectionData = {
+  sessionId: string;
+  totalSize: number;
+  segmentCount: number;
+  data: SegmentFile[];
+};
 
 const formatFileSize = (bytes: number): string => {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const formatSessionTitle = (sessionId: string): string => {
+  // "session_2026-03-09_14-30-45" → "2026/03/09 14:30"
+  const match = sessionId.match(/^session_(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})$/);
+  if (!match) return sessionId;
+  return `${match[1]}/${match[2]}/${match[3]} ${match[4]}:${match[5]}`;
+};
+
+const formatSegmentTime = (segmentId: string): string => {
+  // "segment_2026-03-09_14-30-45" → "14:30:45"
+  const match = segmentId.match(/_(\d{2})-(\d{2})-(\d{2})$/);
+  if (!match) return segmentId;
+  return `${match[1]}:${match[2]}:${match[3]}`;
 };
 
 const UPLOAD_STATUS_LABELS: Record<FileUploadStatus, string> = {
@@ -39,47 +61,54 @@ const UPLOAD_STATUS_COLORS: Record<FileUploadStatus, string> = {
 };
 
 const RecordingsScreen = ({ navigation }: Props) => {
-  const [files, setFiles] = useState<RecordingFile[]>([]);
-  const [selectedUris, setSelectedUris] = useState<Set<string>>(new Set());
+  const [sections, setSections] = useState<SectionData[]>([]);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
   const [uploadStatuses, setUploadStatuses] = useState<Map<string, FileUploadStatus>>(new Map());
   const [isUploading, setIsUploading] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
 
   const loadFiles = useCallback(() => {
-    const recordings = listRecordings();
-    setFiles(recordings);
-    setSelectedUris(new Set());
-    const statuses = new Map<string, FileUploadStatus>();
-    for (const f of recordings) {
-      statuses.set(f.name, getUploadStatusForFile(f.name));
-    }
-    setUploadStatuses(statuses);
+    const sessions = listRecordingSessions();
+    const newSections: SectionData[] = sessions.map((s) => ({
+      sessionId: s.sessionId,
+      totalSize: s.segments.reduce((sum, seg) => sum + seg.size, 0),
+      segmentCount: s.segments.length,
+      data: s.segments,
+    }));
+    setSections(newSections);
+    setSelectedKeys(new Set());
+    setUploadStatuses(getAllUploadStatuses());
   }, []);
 
   useFocusEffect(loadFiles);
 
-  const toggleSelection = (uri: string) => {
-    setSelectedUris((prev) => {
+  const getSegmentKey = (sessionId: string, segmentId: string): string => {
+    return getSegmentPath(sessionId, segmentId);
+  };
+
+  const toggleSelection = (key: string) => {
+    setSelectedKeys((prev) => {
       const next = new Set(prev);
-      if (next.has(uri)) {
-        next.delete(uri);
+      if (next.has(key)) {
+        next.delete(key);
       } else {
-        next.add(uri);
+        next.add(key);
       }
       return next;
     });
   };
 
   const handleDeleteSelected = () => {
-    if (selectedUris.size === 0) return;
-    Alert.alert("選択したファイルを削除", `${selectedUris.size} 件のファイルを削除しますか？`, [
+    if (selectedKeys.size === 0) return;
+    Alert.alert("選択したセグメントを削除", `${selectedKeys.size} 件のセグメントを削除しますか？`, [
       { text: "キャンセル", style: "cancel" },
       {
         text: "削除",
         style: "destructive",
         onPress: () => {
-          for (const uri of selectedUris) {
-            deleteRecording(uri);
+          for (const key of selectedKeys) {
+            const [sessionId, segmentId] = key.split("/");
+            deleteSegment(sessionId, segmentId);
           }
           loadFiles();
         },
@@ -88,8 +117,9 @@ const RecordingsScreen = ({ navigation }: Props) => {
   };
 
   const handleDeleteAll = () => {
-    if (files.length === 0) return;
-    Alert.alert("全件削除", `${files.length} 件のファイルをすべて削除しますか？`, [
+    const totalSegments = sections.reduce((sum, s) => sum + s.segmentCount, 0);
+    if (totalSegments === 0) return;
+    Alert.alert("全件削除", `${totalSegments} 件のセグメントをすべて削除しますか？`, [
       { text: "キャンセル", style: "cancel" },
       {
         text: "全件削除",
@@ -103,15 +133,15 @@ const RecordingsScreen = ({ navigation }: Props) => {
   };
 
   const handleUploadSelected = async () => {
-    if (selectedUris.size === 0) return;
+    if (selectedKeys.size === 0) return;
     if (!isSignedIn()) {
       Alert.alert("サインインが必要", "設定画面から Google アカウントにサインインしてください");
       return;
     }
     setIsUploading(true);
     try {
-      const audioFilenames = files.filter((f) => selectedUris.has(f.uri)).map((f) => f.name);
-      await uploadManual(audioFilenames);
+      const segmentPaths = [...selectedKeys];
+      await uploadManual(segmentPaths);
       loadFiles();
     } catch (e) {
       Alert.alert("アップロードエラー", e instanceof Error ? e.message : "不明なエラー");
@@ -144,28 +174,38 @@ const RecordingsScreen = ({ navigation }: Props) => {
     }
   };
 
-  const handleRowPress = (item: RecordingFile) => {
-    navigation.navigate("Playback", { uri: item.uri, name: item.name });
+  const handleRowPress = (sessionId: string, item: SegmentFile) => {
+    navigation.navigate("Playback", { uri: item.audioUri, name: item.segmentId });
   };
 
-  const renderItem = ({ item }: { item: RecordingFile }) => {
-    const isSelected = selectedUris.has(item.uri);
-    const uploadStatus = uploadStatuses.get(item.name) ?? "not_queued";
+  const renderSectionHeader = ({ section }: { section: SectionData }) => (
+    <View style={styles.sectionHeader}>
+      <Text style={styles.sectionTitle}>{formatSessionTitle(section.sessionId)} 開始</Text>
+      <Text style={styles.sectionMeta}>
+        {section.segmentCount} セグメント / {formatFileSize(section.totalSize)}
+      </Text>
+    </View>
+  );
+
+  const renderItem = ({ item, section }: { item: SegmentFile; section: SectionData }) => {
+    const key = getSegmentKey(section.sessionId, item.segmentId);
+    const isSelected = selectedKeys.has(key);
+    const uploadStatus = uploadStatuses.get(key) ?? "not_queued";
     return (
       <TouchableOpacity
         style={[styles.row, isSelected && styles.rowSelected]}
-        onPress={() => handleRowPress(item)}
+        onPress={() => handleRowPress(section.sessionId, item)}
       >
         <TouchableOpacity
           style={styles.checkbox}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-          onPress={() => toggleSelection(item.uri)}
+          onPress={() => toggleSelection(key)}
         >
           {isSelected && <View style={styles.checkboxInner} />}
         </TouchableOpacity>
         <View style={styles.fileInfo}>
           <Text style={styles.fileName} numberOfLines={1}>
-            {item.name}
+            {formatSegmentTime(item.segmentId)}
           </Text>
           <View style={styles.fileMetaRow}>
             <Text style={styles.fileMeta}>{formatFileSize(item.size)}</Text>
@@ -179,6 +219,8 @@ const RecordingsScreen = ({ navigation }: Props) => {
       </TouchableOpacity>
     );
   };
+
+  const totalSegments = sections.reduce((sum, s) => sum + s.segmentCount, 0);
 
   return (
     <View style={styles.container}>
@@ -195,48 +237,49 @@ const RecordingsScreen = ({ navigation }: Props) => {
           style={[
             styles.toolbarButton,
             styles.uploadButton,
-            (selectedUris.size === 0 || isUploading) && styles.buttonDisabled,
+            (selectedKeys.size === 0 || isUploading) && styles.buttonDisabled,
           ]}
           onPress={handleUploadSelected}
-          disabled={selectedUris.size === 0 || isUploading}
+          disabled={selectedKeys.size === 0 || isUploading}
         >
           <Text style={styles.toolbarButtonText}>
-            {isUploading ? "アップロード中..." : `アップロード (${selectedUris.size})`}
+            {isUploading ? "アップロード中..." : `アップロード (${selectedKeys.size})`}
           </Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={[
             styles.toolbarButton,
             styles.deleteButton,
-            selectedUris.size === 0 && styles.buttonDisabled,
+            selectedKeys.size === 0 && styles.buttonDisabled,
           ]}
           onPress={handleDeleteSelected}
-          disabled={selectedUris.size === 0}
+          disabled={selectedKeys.size === 0}
         >
-          <Text style={styles.toolbarButtonText}>削除 ({selectedUris.size})</Text>
+          <Text style={styles.toolbarButtonText}>削除 ({selectedKeys.size})</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={[
             styles.toolbarButton,
             styles.deleteAllButton,
-            files.length === 0 && styles.buttonDisabled,
+            totalSegments === 0 && styles.buttonDisabled,
           ]}
           onPress={handleDeleteAll}
-          disabled={files.length === 0}
+          disabled={totalSegments === 0}
         >
           <Text style={styles.toolbarButtonText}>全件削除</Text>
         </TouchableOpacity>
       </View>
 
-      {files.length === 0 ? (
+      {totalSegments === 0 ? (
         <View style={styles.emptyContainer}>
           <Text style={styles.emptyText}>録音ファイルがありません</Text>
         </View>
       ) : (
-        <FlatList
-          data={files}
-          keyExtractor={(item) => item.uri}
+        <SectionList
+          sections={sections}
+          keyExtractor={(item, index) => item.segmentId + index}
           renderItem={renderItem}
+          renderSectionHeader={renderSectionHeader}
           contentContainerStyle={styles.list}
           ListFooterComponent={
             <View style={styles.listFooter}>
@@ -296,10 +339,28 @@ const styles = StyleSheet.create({
   list: {
     paddingVertical: 8,
   },
+  sectionHeader: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    backgroundColor: colors.bgSecondary,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderSubtle,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: "bold",
+    color: colors.textPrimary,
+  },
+  sectionMeta: {
+    fontSize: 12,
+    color: colors.textMuted,
+    marginTop: 2,
+  },
   row: {
     flexDirection: "row",
     alignItems: "center",
     paddingHorizontal: 16,
+    paddingLeft: 32,
     paddingVertical: 14,
     borderBottomWidth: 1,
     borderBottomColor: colors.borderSubtle,

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -22,9 +22,13 @@ import {
   getManufacturerGuideUrl,
   openManufacturerGuide,
 } from "@/utils/batteryOptimization";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import type { RootStackParamList } from "../../App";
 import { useGoogleDrive } from "@/hooks/useGoogleDrive";
 
-const SettingsScreen = () => {
+type Props = NativeStackScreenProps<RootStackParamList, "Settings">;
+
+const SettingsScreen = ({ navigation }: Props) => {
   const [splitInterval, setSplitInterval] = useState<number | null>(getSplitIntervalMs);
   const [storageBytes, setStorageBytes] = useState(0);
   const [batteryOptEnabled, setBatteryOptEnabled] = useState(false);
@@ -129,6 +133,13 @@ const SettingsScreen = () => {
           )}
         </>
       )}
+      <Text style={styles.sectionTitle}>デバッグ</Text>
+      <TouchableOpacity
+        style={[styles.actionButton, styles.secondaryButton]}
+        onPress={() => navigation.navigate("DebugLog")}
+      >
+        <Text style={styles.secondaryButtonText}>デバッグログを表示</Text>
+      </TouchableOpacity>
     </ScrollView>
   );
 };

--- a/src/services/uploadManager.ts
+++ b/src/services/uploadManager.ts
@@ -1,5 +1,5 @@
 import NetInfo from "@react-native-community/netinfo";
-import { getRecordingUri } from "@/utils/fileManager";
+import { getAudioUri, getCsvUri } from "@/utils/fileManager";
 import { getGoogleDriveEnabled, getWifiOnlyUpload } from "@/utils/settingsStore";
 import { isSignedIn, getAccessToken } from "@/services/googleAuth";
 import { ensureFolder, uploadMultipart, uploadResumable, fileExists } from "@/services/driveApi";
@@ -43,6 +43,11 @@ const canAutoUpload = async (): Promise<boolean> => {
   return true;
 };
 
+const parseSegmentPath = (segmentPath: string): { sessionId: string; segmentId: string } => {
+  const [sessionId, segmentId] = segmentPath.split("/");
+  return { sessionId, segmentId };
+};
+
 const processPending = async (): Promise<void> => {
   if (isProcessing) return;
   isProcessing = true;
@@ -59,18 +64,31 @@ const processPending = async (): Promise<void> => {
       try {
         markUploading(item.id);
 
+        const { sessionId, segmentId } = parseSegmentPath(item.audio_filename);
         const isAudio = item.file_type === "m4a";
-        const filename = isAudio
-          ? item.audio_filename
-          : item.audio_filename.replace(/\.m4a$/, ".csv");
-        const fileUri = getRecordingUri(filename);
+        const driveFilename = isAudio ? `${segmentId}.m4a` : `${segmentId}.csv`;
+        const fileUri = isAudio
+          ? getAudioUri(sessionId, segmentId)
+          : getCsvUri(sessionId, segmentId);
         const mimeType = isAudio ? "audio/mp4" : "text/csv";
 
         let driveFileId: string;
         if (isAudio) {
-          driveFileId = await uploadResumable(filename, fileUri, mimeType, dateFolderId, token);
+          driveFileId = await uploadResumable(
+            driveFilename,
+            fileUri,
+            mimeType,
+            dateFolderId,
+            token,
+          );
         } else {
-          driveFileId = await uploadMultipart(filename, fileUri, mimeType, dateFolderId, token);
+          driveFileId = await uploadMultipart(
+            driveFilename,
+            fileUri,
+            mimeType,
+            dateFolderId,
+            token,
+          );
         }
 
         markUploaded(item.id, driveFileId);
@@ -88,8 +106,8 @@ export const processUploadQueue = async (): Promise<void> => {
   await processPending();
 };
 
-export const triggerUploadAfterSplit = (audioFilename: string): void => {
-  enqueueRecording(audioFilename);
+export const triggerUploadAfterSplit = (segmentPath: string): void => {
+  enqueueRecording(segmentPath);
   processUploadQueue().catch(() => {});
 };
 
@@ -120,7 +138,7 @@ export const syncDriveStatus = async (): Promise<number> => {
   return resetCount;
 };
 
-export const uploadManual = async (audioFilenames: string[]): Promise<void> => {
+export const uploadManual = async (segmentPaths: string[]): Promise<void> => {
   if (!isSignedIn()) {
     throw new Error("Google アカウントにサインインしてください");
   }
@@ -130,12 +148,12 @@ export const uploadManual = async (audioFilenames: string[]): Promise<void> => {
     throw new Error("ネットワークに接続されていません");
   }
 
-  for (const audioFilename of audioFilenames) {
-    const status = getUploadStatusForFile(audioFilename);
+  for (const segmentPath of segmentPaths) {
+    const status = getUploadStatusForFile(segmentPath);
     if (status === "not_queued") {
-      enqueueRecording(audioFilename);
+      enqueueRecording(segmentPath);
     } else if (status === "failed") {
-      resetForReupload(audioFilename);
+      resetForReupload(segmentPath);
     }
   }
 

--- a/src/services/uploadQueue.ts
+++ b/src/services/uploadQueue.ts
@@ -99,6 +99,38 @@ export const getUploadStatusForFile = (audioFilename: string): FileUploadStatus 
   return "pending";
 };
 
+export const getAllUploadStatuses = (): Map<string, FileUploadStatus> => {
+  const rows = db.getAllSync<{ audio_filename: string; status: UploadStatus }>(
+    "SELECT audio_filename, status FROM upload_queue",
+  );
+
+  // Group statuses by audio_filename
+  const grouped = new Map<string, UploadStatus[]>();
+  for (const row of rows) {
+    const list = grouped.get(row.audio_filename);
+    if (list) {
+      list.push(row.status);
+    } else {
+      grouped.set(row.audio_filename, [row.status]);
+    }
+  }
+
+  // Derive aggregate status per file
+  const result = new Map<string, FileUploadStatus>();
+  for (const [filename, statuses] of grouped) {
+    if (statuses.every((s) => s === "uploaded")) {
+      result.set(filename, "uploaded");
+    } else if (statuses.some((s) => s === "uploading")) {
+      result.set(filename, "uploading");
+    } else if (statuses.some((s) => s === "failed")) {
+      result.set(filename, "failed");
+    } else {
+      result.set(filename, "pending");
+    }
+  }
+  return result;
+};
+
 export const getUploadedItems = (): UploadQueueItem[] => {
   return db.getAllSync<UploadQueueItem>(
     "SELECT * FROM upload_queue WHERE status = 'uploaded' AND drive_file_id IS NOT NULL",

--- a/src/utils/debugLog.ts
+++ b/src/utils/debugLog.ts
@@ -1,4 +1,5 @@
 import { File, Paths } from "expo-file-system/next";
+import { getDebugLogEnabled } from "@/utils/settingsStore";
 
 const LOG_FILE = "debug.log";
 
@@ -8,6 +9,7 @@ const getLogFile = (): File => {
 
 export const appendLog = (message: string): void => {
   try {
+    if (!getDebugLogEnabled()) return;
     const file = getLogFile();
     const timestamp = new Date().toISOString();
     const line = `[${timestamp}] ${message}\n`;

--- a/src/utils/debugLog.ts
+++ b/src/utils/debugLog.ts
@@ -1,0 +1,44 @@
+import { File, Paths } from "expo-file-system/next";
+
+const LOG_FILE = "debug.log";
+
+const getLogFile = (): File => {
+  return new File(Paths.document, LOG_FILE);
+};
+
+export const appendLog = (message: string): void => {
+  try {
+    const file = getLogFile();
+    const timestamp = new Date().toISOString();
+    const line = `[${timestamp}] ${message}\n`;
+    if (file.exists) {
+      const current = file.textSync();
+      file.write(current + line);
+    } else {
+      file.write(line);
+    }
+  } catch {
+    // Silently ignore logging errors
+  }
+};
+
+export const readLog = (): string => {
+  try {
+    const file = getLogFile();
+    if (!file.exists) return "(ログなし)";
+    return file.textSync();
+  } catch {
+    return "(ログ読み取りエラー)";
+  }
+};
+
+export const clearLog = (): void => {
+  try {
+    const file = getLogFile();
+    if (file.exists) {
+      file.delete();
+    }
+  } catch {
+    // Silently ignore
+  }
+};

--- a/src/utils/fileManager.ts
+++ b/src/utils/fileManager.ts
@@ -2,11 +2,15 @@ import { File, Directory, Paths } from "expo-file-system/next";
 
 const RECORDINGS_DIR = "recordings";
 
-export type RecordingFile = {
-  uri: string;
-  name: string;
+export type SegmentFile = {
+  segmentId: string;
+  audioUri: string;
   size: number;
-  createdAt: number | null;
+};
+
+export type RecordingSession = {
+  sessionId: string;
+  segments: SegmentFile[];
 };
 
 const getRecordingDir = (): Directory => {
@@ -31,60 +35,119 @@ const formatTimestamp = (date: Date): string => {
   return `${y}-${mo}-${d}_${h}-${mi}-${s}`;
 };
 
-export const moveRecording = (sourceUri: string): string => {
+export const generateSessionId = (): string => {
+  return `session_${formatTimestamp(new Date())}`;
+};
+
+export const moveRecording = (
+  sourceUri: string,
+  sessionId: string,
+  segmentStartedAt: Date,
+): { sessionId: string; segmentId: string } => {
   ensureRecordingDir();
-  const filename = `recording_${formatTimestamp(new Date())}.m4a`;
-  const dest = new File(getRecordingDir(), filename);
+  const segmentId = `segment_${formatTimestamp(segmentStartedAt)}`;
+
+  const sessionDir = new Directory(getRecordingDir(), sessionId);
+  if (!sessionDir.exists) {
+    sessionDir.create();
+  }
+
+  const segmentDir = new Directory(sessionDir, segmentId);
+  segmentDir.create();
+
+  const dest = new File(segmentDir, "audio.m4a");
   const src = new File(sourceUri);
   src.move(dest);
-  return filename;
+
+  return { sessionId, segmentId };
 };
 
-export const getRecordingUri = (filename: string): string => {
-  return new File(getRecordingDir(), filename).uri;
+export const getAudioUri = (sessionId: string, segmentId: string): string => {
+  return new File(getRecordingDir(), sessionId, segmentId, "audio.m4a").uri;
 };
 
-export const writeDecibelCsv = (csvContent: string, audioFilename: string): string => {
+export const getCsvUri = (sessionId: string, segmentId: string): string => {
+  return new File(getRecordingDir(), sessionId, segmentId, "decibel.csv").uri;
+};
+
+export const getSegmentPath = (sessionId: string, segmentId: string): string => {
+  return `${sessionId}/${segmentId}`;
+};
+
+export const writeDecibelCsv = (
+  csvContent: string,
+  sessionId: string,
+  segmentId: string,
+): string => {
   ensureRecordingDir();
-  const csvFilename = audioFilename.replace(/\.m4a$/, ".csv");
-  const dest = new File(getRecordingDir(), csvFilename);
+  const dest = new File(getRecordingDir(), sessionId, segmentId, "decibel.csv");
   dest.write(csvContent);
   return dest.uri;
 };
 
-export const listRecordings = (): RecordingFile[] => {
+export const listRecordingSessions = (): RecordingSession[] => {
   const dir = getRecordingDir();
   if (!dir.exists) {
     return [];
   }
+
+  const sessions: RecordingSession[] = [];
   const entries = dir.list();
-  const files: RecordingFile[] = [];
+
   for (const entry of entries) {
-    if (entry instanceof File) {
-      const name = entry.uri.split("/").pop() ?? entry.uri;
-      if (!name.endsWith(".m4a")) continue;
-      files.push({
-        uri: entry.uri,
-        name,
-        size: entry.size ?? 0,
-        createdAt: null,
+    if (!(entry instanceof Directory)) continue;
+    const sessionId = entry.name;
+    if (!sessionId.startsWith("session_")) continue;
+
+    const segments: SegmentFile[] = [];
+    const segEntries = entry.list();
+
+    for (const segEntry of segEntries) {
+      if (!(segEntry instanceof Directory)) continue;
+      const segmentId = segEntry.name;
+      if (!segmentId.startsWith("segment_")) continue;
+
+      const audioFile = new File(segEntry, "audio.m4a");
+      if (!audioFile.exists) continue;
+
+      segments.push({
+        segmentId,
+        audioUri: audioFile.uri,
+        size: audioFile.size ?? 0,
       });
     }
+
+    segments.sort((a, b) => a.segmentId.localeCompare(b.segmentId));
+
+    if (segments.length > 0) {
+      sessions.push({ sessionId, segments });
+    }
   }
-  // Sort by name descending (newest first, since names contain timestamps)
-  files.sort((a, b) => b.name.localeCompare(a.name));
-  return files;
+
+  sessions.sort((a, b) => b.sessionId.localeCompare(a.sessionId));
+  return sessions;
 };
 
-export const deleteRecording = (uri: string): void => {
-  const file = new File(uri);
-  if (file.exists) {
-    file.delete();
+export const deleteSegment = (sessionId: string, segmentId: string): void => {
+  const segmentDir = new Directory(getRecordingDir(), sessionId, segmentId);
+  if (segmentDir.exists) {
+    segmentDir.delete();
   }
-  const csvUri = uri.replace(/\.m4a$/, ".csv");
-  const csvFile = new File(csvUri);
-  if (csvFile.exists) {
-    csvFile.delete();
+
+  // Remove session dir if empty
+  const sessionDir = new Directory(getRecordingDir(), sessionId);
+  if (sessionDir.exists) {
+    const remaining = sessionDir.list();
+    if (remaining.length === 0) {
+      sessionDir.delete();
+    }
+  }
+};
+
+export const deleteSession = (sessionId: string): void => {
+  const sessionDir = new Directory(getRecordingDir(), sessionId);
+  if (sessionDir.exists) {
+    sessionDir.delete();
   }
 };
 
@@ -95,7 +158,10 @@ export const deleteAllRecordings = (): void => {
   }
   const entries = dir.list();
   for (const entry of entries) {
-    if (entry instanceof File) {
+    if (entry instanceof Directory) {
+      entry.delete();
+    } else if (entry instanceof File) {
+      // Clean up any leftover flat files
       entry.delete();
     }
   }

--- a/src/utils/settingsStore.ts
+++ b/src/utils/settingsStore.ts
@@ -12,6 +12,7 @@ db.execSync(
 const KEY_SPLIT_INTERVAL = "split_interval_ms";
 const KEY_GOOGLE_DRIVE_ENABLED = "google_drive_enabled";
 const KEY_WIFI_ONLY_UPLOAD = "wifi_only_upload";
+const KEY_DEBUG_LOG_ENABLED = "debug_log_enabled";
 
 export type SplitIntervalOption = {
   label: string;
@@ -77,6 +78,22 @@ export const setWifiOnlyUpload = (value: boolean): void => {
   db.runSync(
     "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
     KEY_WIFI_ONLY_UPLOAD,
+    String(value),
+  );
+};
+
+export const getDebugLogEnabled = (): boolean => {
+  const row = db.getFirstSync<{ value: string }>(
+    "SELECT value FROM settings WHERE key = ?",
+    KEY_DEBUG_LOG_ENABLED,
+  );
+  return row?.value === "true";
+};
+
+export const setDebugLogEnabled = (value: boolean): void => {
+  db.runSync(
+    "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+    KEY_DEBUG_LOG_ENABLED,
     String(value),
   );
 };

--- a/src/utils/storageUsage.ts
+++ b/src/utils/storageUsage.ts
@@ -2,18 +2,23 @@ import { File, Directory, Paths } from "expo-file-system/next";
 
 const RECORDINGS_DIR = "recordings";
 
-export const getTotalStorageBytes = (): number => {
-  const dir = new Directory(Paths.document, RECORDINGS_DIR);
-  if (!dir.exists) return 0;
-
+const sumDirectorySize = (dir: Directory): number => {
   let total = 0;
   const entries = dir.list();
   for (const entry of entries) {
     if (entry instanceof File) {
       total += entry.size ?? 0;
+    } else if (entry instanceof Directory) {
+      total += sumDirectorySize(entry);
     }
   }
   return total;
+};
+
+export const getTotalStorageBytes = (): number => {
+  const dir = new Directory(Paths.document, RECORDINGS_DIR);
+  if (!dir.exists) return 0;
+  return sumDirectorySize(dir);
 };
 
 export const formatBytes = (bytes: number): string => {


### PR DESCRIPTION
## Summary
- 録音ファイルを `session_*/segment_*/` の2階層ディレクトリ構造で管理するように移行
- 分割録音が同一セッションに属することをディレクトリ構造 + UI のセクションヘッダーで表現
- セグメントIDに録音開始時刻を使用し、セッションヘッダーとの整合性を確保
- アップロードステータスを一括取得（N回→1回のSQLクエリ）で画面表示を高速化
- デバッグログ機能（`debugLog.ts`）とログ閲覧専用画面（`DebugLogScreen`）を追加

## Test plan
- [x] 新規録音がセッション/セグメントのディレクトリ構造で保存されること
- [x] ファイル一覧がセッション単位でグルーピング表示されること
- [x] セグメントの個別削除・全件削除が正常に動作すること
- [x] 再生・アップロードが新構造で動作すること
- [x] ストレージ使用量が正しく計算されること
- [x] 設定画面からデバッグログ画面に遷移できること
- [ ] CI が通ること

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
